### PR TITLE
Work to enable HID reconnect

### DIFF
--- a/vrpn_HumanInterface.C
+++ b/vrpn_HumanInterface.C
@@ -91,11 +91,12 @@ bool vrpn_HidInterface::reconnect()
         loop = loop->next;
     }
     if (!found) {
-        fprintf(stderr, "vrpn_HidInterface::reconnect(): Device not found\n");
+        //fprintf(stderr, "vrpn_HidInterface::reconnect(): Device not found\n");
         hid_free_enumeration(devs);
         devs = NULL;
         return false;
     }
+
 
     // Initialize the HID interface and open the device.
     _device = hid_open_path(path);
@@ -167,6 +168,7 @@ void vrpn_HidInterface::update()
                     "vrpn_HidInterface::update(): error message: %ls\n",
                     errmsg);
             }
+            _working = false;
             return;
         }
 

--- a/vrpn_Tracker_OSVRHackerDevKit.C
+++ b/vrpn_Tracker_OSVRHackerDevKit.C
@@ -107,6 +107,11 @@ void vrpn_Tracker_OSVRHackerDevKit::mainloop()
     }
     _wasConnected = connected();
 
+    if (!_wasConnected) {
+        _acceptor->reset();
+        reconnect();
+    }
+
     server_mainloop();
 }
 


### PR DESCRIPTION
Added reset() and reconnect() calls to HDK and Razer Hydra drivers. Removed noisy error message when HID driver is not found.

Tested to work with HDK and Razer Hydra. Shouldn't break other devices, but if other devices want to get reconnect/hot-replug functionality, then they have to check `connected()`, and if necessary, reset the acceptors and call `reconnect()` themselves.