### PR TITLE
Avoid null endpoints

### DIFF
--- a/vrpn_Connection.C
+++ b/vrpn_Connection.C
@@ -5865,7 +5865,10 @@ void vrpn_Connection_IP::server_check_for_incoming_connections(
 void vrpn_Connection_IP::drop_connection(int whichEndpoint)
 {
     vrpn_Endpoint *endpoint = d_endpoints[whichEndpoint];
-
+    if (!endpoint) {
+        /// @todo sometimes we end up in here with a null endpoint?
+        return;
+    }
     endpoint->drop_connection();
 
     // If we're a client, try to reconnect to the server

--- a/vrpn_Connection.C
+++ b/vrpn_Connection.C
@@ -4800,6 +4800,10 @@ int vrpn_Connection::delete_endpoint(int endpointIndex)
         delete endpoint;
     }
     d_endpoints[endpointIndex] = NULL;
+    if (d_numEndpoints == endpointIndex + 1) {
+        // This was the last endpoint in the list, can shrink it.
+        d_numEndpoints--;
+    }
 
     return 0;
 }

--- a/vrpn_Connection.C
+++ b/vrpn_Connection.C
@@ -4724,6 +4724,9 @@ int vrpn_Connection::register_log_filter(vrpn_LOGFILTER filter, void *userdata)
 {
     int i;
     for (i = 0; i < d_numEndpoints; i++) {
+        if (!d_endpoints[i]) {
+            continue;
+        }
         d_endpoints[i]->d_inLog->addFilter(filter, userdata);
         d_endpoints[i]->d_outLog->addFilter(filter, userdata);
     }
@@ -4736,6 +4739,9 @@ int vrpn_Connection::save_log_so_far()
     int i;
     int final_retval = 0;
     for (i = 0; i < d_numEndpoints; i++) {
+        if (!d_endpoints[i]) {
+            continue;
+        }
         final_retval |= d_endpoints[i]->d_inLog->saveLogSoFar();
         final_retval |= d_endpoints[i]->d_outLog->saveLogSoFar();
     }


### PR DESCRIPTION
This should at least trivially work around #83, though I'd really like to factor out that endpoint array into its own class to keep all its logic together and be able to actually enforce invariants.

I think the last commit is reasonable, but I'd particularly like review on it, since I haven't worked in this part of the codebase a lot so I want to make sure that there's no concept problem there.