### PR TITLE
Fix for wait3 removal from Android NDK

### DIFF
--- a/vrpn_Connection.C
+++ b/vrpn_Connection.C
@@ -2549,6 +2549,8 @@ static int vrpn_start_server(const char *machine, char *server_name, char *args,
     defined(__APPLE__)
             /* hpux include files have the wrong declaration */
             deadkid = wait3((int *)&status, WNOHANG, NULL);
+#elif defined(__ANDROID__)
+            deadkid = waitpid(-1, &status, WNOHANG);
 #else
             deadkid = wait3(&status, WNOHANG, NULL);
 #endif


### PR DESCRIPTION
This replaces wait3 (deprecated obsolete function) with an equivalent call
to waitpid() on Android. This function is available from Android API level 3
so it should be pretty safe thing to do.