### PR TITLE
Chrono clock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1400,7 +1400,7 @@ endif()
 
 #-----------------------------------------------------------------------------
 # Testing applications that live in the main directory.
-if(VRPN_BUILD_SERVERS AND VRPN_BUILD_SERVER_LIBRARY AND BUILD_TESTING AND WIN32)
+if(BUILD_TESTING)
 	foreach(SOURCE time_test.cpp)
 		get_filename_component(APP ${SOURCE} NAME_WE)
 		add_executable(${APP} ${SOURCE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,6 +904,10 @@ if(UNIX)
 
 endif()
 
+# This will only work on compilers that support C++-11.
+# We could check for this and turn it on by default.
+option(VRPN_USE_STD_CHRONO "Use the std::chrono class for time" OFF)
+
 option(VRPN_USE_STATIC_ASSERTIONS "Use some compile-time assertions" ON)
 option(VRPN_BUILD_EXTRA_COMPILER_WARNINGS
 	"Build with flags to enable extra warnings."

--- a/time_test.cpp
+++ b/time_test.cpp
@@ -1,10 +1,11 @@
+#include "vrpn_Shared.h"
+#include <stdio.h>
+
 // Avoid warning on the call of _ftime()
 #ifdef  _WIN32
 #define _CRT_SECURE_NO_WARNINGS
 
-#include "vrpn_Shared.h"
 #include <winbase.h>
-#include <stdio.h>
 #include <math.h>
 #include <sys/types.h>
 #include <sys/timeb.h>
@@ -109,7 +110,7 @@ int main(int argc, char *argv[]) {
   double skip;
   vrpn_gettimeofday(&last_time, NULL);
   printf("Checking for monotonicity and step size\n");
-  printf(" (should be no further output if things are working)\n");
+  printf(" (should be no further output if things are working perfectly)\n");
   while (true) {
     vrpn_gettimeofday(&this_time, NULL);
 	skip = vrpn_TimevalDurationSeconds(this_time, last_time);
@@ -119,9 +120,6 @@ int main(int argc, char *argv[]) {
     if (skip < 0) {
   		printf("** Backwards %lg microseconds\n", skip*1e6);
     }
-    if (skip == 0) {
-      printf("** Repeated time\n");
-    }
     last_time = this_time;
   }
 
@@ -129,10 +127,25 @@ int main(int argc, char *argv[]) {
 }
 
 #else
-#include <stdio.h>
 int main(void)
 {
-	fprintf(stderr,"Program not ported to other than Windows\n");
-	return -1;
+  /* Checking the vrpn_gettimeofday() function for monotonicity and step size */
+  struct timeval last_time, this_time;
+  double skip;
+  vrpn_gettimeofday(&last_time, NULL);
+  printf("Checking for monotonicity and step size\n");
+  printf(" (should be no further output if things are working perfectly)\n");
+  while (true) {
+    vrpn_gettimeofday(&this_time, NULL);
+	skip = vrpn_TimevalDurationSeconds(this_time, last_time);
+    if (skip > 200e-6) {
+      printf("Skipped forward %lg microseconds\n", skip*1e6);
+    }
+    if (skip < 0) {
+  		printf("** Backwards %lg microseconds\n", skip*1e6);
+    }
+    last_time = this_time;
+  }
+	return 0;
 }
 #endif

--- a/time_test.cpp
+++ b/time_test.cpp
@@ -104,24 +104,28 @@ int main(int argc, char *argv[]) {
 		printf("  Converted to secs and usecs: %6lu:%6lu\n", sec, usec);
 	}
 
-    /* Checking the vrpn_gettimeofday() function for monotonicity and step size */
-    struct timeval last_time, this_time;
-    double skip;
-    vrpn_gettimeofday(&last_time, NULL);
-    printf("Should be no further output if things are working\n");
-    while (true) {
-      vrpn_gettimeofday(&this_time, NULL);
-	  skip = vrpn_TimevalDurationSeconds(this_time, last_time);
-      if (skip > 200e-6) {
-        printf("Skipped forward %lg microseconds\n", skip*1e6);
-      }
-      if (skip < 0) {
-		  printf("** Backwards %lg microseconds\n", skip*1e6);
-      }
-      last_time = this_time;
+  /* Checking the vrpn_gettimeofday() function for monotonicity and step size */
+  struct timeval last_time, this_time;
+  double skip;
+  vrpn_gettimeofday(&last_time, NULL);
+  printf("Checking for monotonicity and step size\n");
+  printf(" (should be no further output if things are working)\n");
+  while (true) {
+    vrpn_gettimeofday(&this_time, NULL);
+	skip = vrpn_TimevalDurationSeconds(this_time, last_time);
+    if (skip > 200e-6) {
+      printf("Skipped forward %lg microseconds\n", skip*1e6);
     }
+    if (skip < 0) {
+  		printf("** Backwards %lg microseconds\n", skip*1e6);
+    }
+    if (skip == 0) {
+      printf("** Repeated time\n");
+    }
+    last_time = this_time;
+  }
 
-    return 0;
+  return 0;
 }
 
 #else

--- a/vrpn_Configure.h.cmake_in
+++ b/vrpn_Configure.h.cmake_in
@@ -52,6 +52,10 @@
 #define vrpn_DEFAULT_LISTEN_PORT_NO (3883)
 
 //-----------------------
+// Use the std::chrono library for time, rather than gettimeofday.
+#cmakedefine VRPN_USE_STD_CHRONO
+
+//-----------------------
 // Use compile-time static asserts.
 #cmakedefine VRPN_USE_STATIC_ASSERTIONS
 

--- a/vrpn_Shared.C
+++ b/vrpn_Shared.C
@@ -396,9 +396,12 @@ VRPN_API int vrpn_unbuffer(const char **buffer, char *string, vrpn_int32 length)
 #include <ctime>
 
 ///////////////////////////////////////////////////////////////
-// With Visual Studio 2013, this produces a clock that has a
+// With Visual Studio 2013 64-bit, this produces a clock that has a
 // tick interval of around 15.6 MILLIseconds, repeating the same
 // time between them.
+///////////////////////////////////////////////////////////////
+// With Visual Studio 2015 64-bit, this produces a good, high-
+// resolution clock with no blips.
 ///////////////////////////////////////////////////////////////
 
 extern "C" VRPN_API int vrpn_gettimeofday(struct timeval *tp, void *tzp)

--- a/vrpn_Shared.h
+++ b/vrpn_Shared.h
@@ -90,7 +90,9 @@
 // If we're using std::chrono, then we implement a new
 // vrpn_gettimeofday() on top of it in a platform-independent
 // manner.  Otherwise, we just use the system call.
-#ifndef VRPN_USE_STD_CHRONO
+#ifdef VRPN_USE_STD_CHRONO
+  extern "C" VRPN_API int vrpn_gettimeofday(struct timeval *tp, void *tzp);
+#else
   #define vrpn_gettimeofday gettimeofday
 #endif
 #else // winsock sockets
@@ -119,7 +121,7 @@
 #endif
 
 // Whether or not we export gettimeofday, we declare the
-// vrpn_gettimeofday() function.
+// vrpn_gettimeofday() function on Windows.
 extern "C" VRPN_API int vrpn_gettimeofday(struct timeval *tp, void *tzp);
 
 // If compiling under Cygnus Solutions Cygwin then these get defined by

--- a/vrpn_Shared.h
+++ b/vrpn_Shared.h
@@ -87,7 +87,12 @@
 
 #if (!defined(VRPN_USE_WINSOCK_SOCKETS))
 #include <sys/time.h> // for timeval, timezone, gettimeofday
-#define vrpn_gettimeofday gettimeofday
+// If we're using std::chrono, then we implement a new
+// vrpn_gettimeofday() on top of it in a platform-independent
+// manner.  Otherwise, we just use the system call.
+#ifndef VRPN_USE_STD_CHRONO
+  #define vrpn_gettimeofday gettimeofday
+#endif
 #else // winsock sockets
 
 // These are a pair of horrible hacks that instruct Windows include

--- a/vrpn_Streaming_Arduino.C
+++ b/vrpn_Streaming_Arduino.C
@@ -213,7 +213,7 @@ int vrpn_Streaming_Arduino::get_report(void)
       // seconds per character (a little under a tenth of a milli-
       // second).  So we get about 1ms of delay for every 10
       // characters.
-      long offset_usec = 87 * m_buffer.size();
+      long offset_usec = static_cast<long>(87 * m_buffer.size());
       struct timeval offset = { 0 , offset_usec };
       m_timestamp = vrpn_TimevalDiff(read_time, offset);
 


### PR DESCRIPTION
Made a (default-off) VRPN_USE_STD_CHRONO definition that replaces the vrpn_gettimeofday() calls to gettimeofday() on non-Windows and various high-performance Windows clocks with calls to std::chrono.  Tested on mac, linux, and windows.  On Windows, Visual Studio 2015 produces a high-resolution clock but Visual Studio 2013 does not (still produces a clock, but it ticks at around 15.6 milliseconds).