### PR TITLE
Support for Wireless 3DConnexion SpaceMouse (Pro & Non Pro)

### DIFF
--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -2063,6 +2063,7 @@
 #vrpn_3DConnexion_SpaceMouse device0
 #vrpn_3DConnexion_SpaceMousePro device0
 #vrpn_3DConnexion_SpaceMouseWireless device0
+#vrpn_3DConnexion_SpaceMouseProWireless device0
 #vrpn_3DConnexion_SpaceExplorer device0
 #vrpn_3DConnexion_SpaceBall5000 device0
 #vrpn_3DConnexion_SpacePilot spacepilot

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -5225,6 +5225,10 @@ vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
                     VRPN_CHECK(templated_setup_device_name_only<
                         vrpn_3DConnexion_SpaceMousePro>);
                 }
+                else if (VRPN_ISIT("vrpn_3DConnexion_SpaceMouseProWireless")) {
+                    VRPN_CHECK(templated_setup_device_name_only<
+                        vrpn_3DConnexion_SpaceMouseProWireless>);
+                }
                 else if (VRPN_ISIT("vrpn_3DConnexion_SpaceMouseWireless")) {
                     VRPN_CHECK(templated_setup_device_name_only<
                         vrpn_3DConnexion_SpaceMouseWireless>);

--- a/vrpn_3DConnexion.C
+++ b/vrpn_3DConnexion.C
@@ -313,102 +313,82 @@ void vrpn_3DConnexion::decodePacket(size_t bytes, vrpn_uint8 *buffer)
 
 void vrpn_3DConnexionWireless::decodePacket(size_t bytes, vrpn_uint8 *buffer)
 {
-	// The wireless versions send 13 bytes, not 7.
-	//We do the same check on size as the non wireless version
-	if (bytes<13) bytes=13;
-	if (bytes > 13) {
-		fprintf(stderr, "vrpn_3DConnexionWireless::decodePacket(): Long packet (%d bytes), may mis-parse\n",
-			static_cast<int>(bytes));
-	}
-	// Decode all full reports.
-	// Just like the wired the first byte is the report type.
-	// Unlike the wired the wireless mice only send report type 1 & 3 (and 23) but not 2.
-	// 23 appears to be a new report type that signals and end of mouse movement.
-	// Report type 1 is then followed by both translation and rotation.
-	for (size_t i = 0; i < bytes / 13; i++) {
-		vrpn_uint8 *report = buffer + (i * 13);
+  // The wireless versions send 13 bytes, not 7.
+  //We do the same check on size as the non wireless version
+  if (bytes<13) bytes=13;
+  if (bytes > 13) {
+    fprintf(stderr, "vrpn_3DConnexionWireless::decodePacket(): Long packet (%d bytes), may mis-parse\n",
+      static_cast<int>(bytes));
+  }
+  // Decode all full reports.
+  // Just like the wired the first byte is the report type.
+  // Unlike the wired the wireless mice only send report type 1 & 3 (and 23) but not 2.
+  // 23 appears to be a new report type that signals and end of mouse movement.
+  // Report type 1 is then followed by both translation and rotation.
+  for (size_t i = 0; i < bytes / 13; i++) {
+    vrpn_uint8 *report = buffer + (i * 13);
 
-		// There are three types of reports.  Parse whichever type this is.
-		char  report_type = report[0];
-		vrpn_uint8 *bufptr = &report[1];
-		//The wireless version reports out of 350, compared to out of 400 for the wired.
-		const float scale = 1.0f/350.0f;
-		switch (report_type)  {
-			// Report types 1 and 2 come one after the other.  Each seems
-			// to change when the puck is moved.  It looks like each pair
-			// of values records a signed value for one channel; report
-			// type 1 is translation and report type 2 is rotation.
-			// The minimum and maximum values seem to vary somewhat.
-			// They all seem to be able to get over 400, so we scale
-			// by 400 and then clamp to (-1..1).
-			// The first byte is the low-order byte and the second is the
-			// high-order byte.
-		case 1:
-			channel[0] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
-			if (channel[0] < -1.0) { channel[0] = -1.0; }
-			if (channel[0] > 1.0) { channel[0] = 1.0; }
-			channel[1] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
-			if (channel[1] < -1.0) { channel[1] = -1.0; }
-			if (channel[1] > 1.0) { channel[1] = 1.0; }
-			channel[2] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
-			if (channel[2] < -1.0) { channel[2] = -1.0; }
-			if (channel[2] > 1.0) { channel[2] = 1.0; }
-			channel[3] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
-			if (channel[3] < -1.0) { channel[3] = -1.0; }
-			if (channel[3] > 1.0) { channel[3] = 1.0; }
-			channel[4] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
-			if (channel[4] < -1.0) { channel[4] = -1.0; }
-			if (channel[4] > 1.0) { channel[4] = 1.0; }
-			channel[5] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
-			if (channel[5] < -1.0) { channel[5] = -1.0; }
-			if (channel[5] > 1.0) { channel[5] = 1.0; }
-			break;
+    // There are three types of reports.  Parse whichever type this is.
+    char  report_type = report[0];
+    vrpn_uint8 *bufptr = &report[1];
+    //The wireless version reports out of 350, compared to out of 400 for the wired.
+    const float scale = 1.0f/350.0f;
+    switch (report_type)  {
+      // Report types 1 and 2 come one after the other.  Each seems
+      // to change when the puck is moved.  It looks like each pair
+      // of values records a signed value for one channel; report
+      // type 1 is translation and report type 2 is rotation.
+      // The minimum and maximum values seem to vary somewhat.
+      // They all seem to be able to get over 400, so we scale
+      // by 400 and then clamp to (-1..1).
+      // The first byte is the low-order byte and the second is the
+      // high-order byte.
+    case 1:
+      channel[0] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+      if (channel[0] < -1.0) { channel[0] = -1.0; }
+      if (channel[0] > 1.0) { channel[0] = 1.0; }
+      channel[1] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+      if (channel[1] < -1.0) { channel[1] = -1.0; }
+      if (channel[1] > 1.0) { channel[1] = 1.0; }
+      channel[2] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+      if (channel[2] < -1.0) { channel[2] = -1.0; }
+      if (channel[2] > 1.0) { channel[2] = 1.0; }
+      channel[3] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+      if (channel[3] < -1.0) { channel[3] = -1.0; }
+      if (channel[3] > 1.0) { channel[3] = 1.0; }
+      channel[4] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+      if (channel[4] < -1.0) { channel[4] = -1.0; }
+      if (channel[4] > 1.0) { channel[4] = 1.0; }
+      channel[5] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+      if (channel[5] < -1.0) { channel[5] = -1.0; }
+      if (channel[5] > 1.0) { channel[5] = 1.0; }
+      break;
 
-		case 3: { // Button report
-					int btn;
+    case 3: { // Button report
+      int btn;
 
-					// Button reports are encoded as bits in the first 2 bytes
-					// after the type.  There can be more than one byte if there
-					// are more than 8 buttons such as on SpaceExplorer or SpaceBall5000.
-					// If 8 or less, we don't look at 2nd byte.
-					// SpaceExplorer buttons are (for example):
-					// Name           Number
-					// 1              0
-					// 2              1
-					// T              2
-					// L              3
-					// R              4
-					// F              5
-					// ESC            6
-					// ALT            7
-					// SHIFT          8
-					// CTRL           9
-					// FIT            10
-					// PANEL          11
-					// +              12
-					// -              13
-					// 2D             14
+      // Button reports are encoded as per non-wirless version.
 
-					for (btn = 0; btn < vrpn_Button::num_buttons; btn++) {
-						vrpn_uint8 *location, mask;
-						location = report + 1 + (btn / 8);
-						mask = 1 << (btn % 8);
-						buttons[btn] = ((*location) & mask) != 0;
-					}
-					break;
-		}
+      for (btn = 0; btn < vrpn_Button::num_buttons; btn++) {
+        vrpn_uint8 *location, mask;
+        location = report + 1 + (btn / 8);
+        mask = 1 << (btn % 8);
+        buttons[btn] = ((*location) & mask) != 0;
+      }
+      break;
+    }
 
     case 23:
       //No need to take action. It just indicates user has stopped using the mouse.
       break;    
 
-		default:
-			vrpn_gettimeofday(&_timestamp, NULL);
-			send_text_message("Unknown report type", _timestamp, vrpn_TEXT_WARNING);
-		}
-		// Report this event before parsing the next.
-		report_changes();
-	}
+    default:
+      vrpn_gettimeofday(&_timestamp, NULL);
+      send_text_message("Unknown report type", _timestamp, vrpn_TEXT_WARNING);
+    }
+    // Report this event before parsing the next.
+    report_changes();
+  }
 }
 #endif
 

--- a/vrpn_3DConnexion.C
+++ b/vrpn_3DConnexion.C
@@ -396,11 +396,11 @@ void vrpn_3DConnexionWireless::decodePacket(size_t bytes, vrpn_uint8 *buffer)
 						buttons[btn] = ((*location) & mask) != 0;
 					}
 					break;
-
-		case 23:
-			//No need to take action. It just indicates user has stopped using the mouse.
-			break;
 		}
+
+    case 23:
+      //No need to take action. It just indicates user has stopped using the mouse.
+      break;    
 
 		default:
 			vrpn_gettimeofday(&_timestamp, NULL);

--- a/vrpn_3DConnexion.C
+++ b/vrpn_3DConnexion.C
@@ -33,6 +33,7 @@ static const vrpn_uint16 vrpn_3DCONNEXION_SPACEMOUSEPRO = 50731;
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEMOUSEWIRELESS = 50735;
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEBALL5000 = 0xc621;   // 50721;
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEPILOT =  0xc625;
+static const vrpn_uint16 vrpn_3DCONNEXION_SPACEMOUSEPROWIRELESS = 50738;
 
 vrpn_3DConnexion::vrpn_3DConnexion(vrpn_HidAcceptor *filter, unsigned num_buttons,
                                    const char *name, vrpn_Connection *c,
@@ -309,7 +310,114 @@ void vrpn_3DConnexion::decodePacket(size_t bytes, vrpn_uint8 *buffer)
     report_changes();
   }
 }
+
+void vrpn_3DConnexionWireless::decodePacket(size_t bytes, vrpn_uint8 *buffer)
+{
+	// The wireless versions send 13 bytes, not 7.
+	//We do the same check on size as the non wireless version
+	if (bytes<13) bytes=13;
+	if (bytes > 13) {
+		fprintf(stderr, "vrpn_3DConnexionWireless::decodePacket(): Long packet (%d bytes), may mis-parse\n",
+			static_cast<int>(bytes));
+	}
+	// Decode all full reports.
+	// Just like the wired the first byte is the report type.
+	// Unlike the wired the wireless mice only send report type 1 & 3 (and 23) but not 2.
+	// 23 appears to be a new report type that signals and end of mouse movement.
+	// Report type 1 is then followed by both translation and rotation.
+	for (size_t i = 0; i < bytes / 13; i++) {
+		vrpn_uint8 *report = buffer + (i * 13);
+
+		// There are three types of reports.  Parse whichever type this is.
+		char  report_type = report[0];
+		vrpn_uint8 *bufptr = &report[1];
+		//The wireless version reports out of 350, compared to out of 400 for the wired.
+		const float scale = 1.0f/350.0f;
+		switch (report_type)  {
+			// Report types 1 and 2 come one after the other.  Each seems
+			// to change when the puck is moved.  It looks like each pair
+			// of values records a signed value for one channel; report
+			// type 1 is translation and report type 2 is rotation.
+			// The minimum and maximum values seem to vary somewhat.
+			// They all seem to be able to get over 400, so we scale
+			// by 400 and then clamp to (-1..1).
+			// The first byte is the low-order byte and the second is the
+			// high-order byte.
+		case 1:
+			channel[0] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+			if (channel[0] < -1.0) { channel[0] = -1.0; }
+			if (channel[0] > 1.0) { channel[0] = 1.0; }
+			channel[1] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+			if (channel[1] < -1.0) { channel[1] = -1.0; }
+			if (channel[1] > 1.0) { channel[1] = 1.0; }
+			channel[2] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+			if (channel[2] < -1.0) { channel[2] = -1.0; }
+			if (channel[2] > 1.0) { channel[2] = 1.0; }
+			channel[3] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+			if (channel[3] < -1.0) { channel[3] = -1.0; }
+			if (channel[3] > 1.0) { channel[3] = 1.0; }
+			channel[4] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+			if (channel[4] < -1.0) { channel[4] = -1.0; }
+			if (channel[4] > 1.0) { channel[4] = 1.0; }
+			channel[5] = vrpn_unbuffer_from_little_endian<vrpn_int16>(bufptr) * scale;
+			if (channel[5] < -1.0) { channel[5] = -1.0; }
+			if (channel[5] > 1.0) { channel[5] = 1.0; }
+			break;
+
+		case 3: { // Button report
+					int btn;
+
+					// Button reports are encoded as bits in the first 2 bytes
+					// after the type.  There can be more than one byte if there
+					// are more than 8 buttons such as on SpaceExplorer or SpaceBall5000.
+					// If 8 or less, we don't look at 2nd byte.
+					// SpaceExplorer buttons are (for example):
+					// Name           Number
+					// 1              0
+					// 2              1
+					// T              2
+					// L              3
+					// R              4
+					// F              5
+					// ESC            6
+					// ALT            7
+					// SHIFT          8
+					// CTRL           9
+					// FIT            10
+					// PANEL          11
+					// +              12
+					// -              13
+					// 2D             14
+
+					for (btn = 0; btn < vrpn_Button::num_buttons; btn++) {
+						vrpn_uint8 *location, mask;
+						location = report + 1 + (btn / 8);
+						mask = 1 << (btn % 8);
+						buttons[btn] = ((*location) & mask) != 0;
+					}
+					break;
+
+		case 23:
+			//No need to take action. It just indicates user has stopped using the mouse.
+			break;
+		}
+
+		default:
+			vrpn_gettimeofday(&_timestamp, NULL);
+			send_text_message("Unknown report type", _timestamp, vrpn_TEXT_WARNING);
+		}
+		// Report this event before parsing the next.
+		report_changes();
+	}
+}
 #endif
+
+vrpn_3DConnexionWireless::vrpn_3DConnexionWireless(vrpn_HidAcceptor *filter, unsigned num_buttons,
+	const char *name, vrpn_Connection *c,
+	vrpn_uint16 vendor, vrpn_uint16 product)
+	: vrpn_3DConnexion(filter, num_buttons, name, c, vendor, product)
+{
+}
 
 vrpn_3DConnexion_Navigator::vrpn_3DConnexion_Navigator(const char *name, vrpn_Connection *c)
     : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR), 2, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR)
@@ -337,7 +445,7 @@ vrpn_3DConnexion_SpaceMousePro::vrpn_3DConnexion_SpaceMousePro(const char *name,
 }
 
 vrpn_3DConnexion_SpaceMouseWireless::vrpn_3DConnexion_SpaceMouseWireless(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEWIRELESS), 2, name, c, vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEWIRELESS)
+	: vrpn_3DConnexionWireless(_filter = new vrpn_HidProductAcceptor(vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEWIRELESS), 2, name, c, vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEWIRELESS)
 {
 }
 
@@ -354,4 +462,9 @@ vrpn_3DConnexion_SpaceBall5000::vrpn_3DConnexion_SpaceBall5000(const char *name,
 vrpn_3DConnexion_SpacePilot::vrpn_3DConnexion_SpacePilot(const char *name, vrpn_Connection *c)
     : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEPILOT), 21, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEPILOT)
 {
+}
+
+vrpn_3DConnexion_SpaceMouseProWireless::vrpn_3DConnexion_SpaceMouseProWireless(const char *name, vrpn_Connection *c)
+	: vrpn_3DConnexionWireless(_filter = new vrpn_HidProductAcceptor(vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEPROWIRELESS), 27, name, c, vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEPROWIRELESS)
+{	// 15 physical buttons are numbered: 0-2, 4-5, 8, 12-15, 22-26
 }

--- a/vrpn_3DConnexion.h
+++ b/vrpn_3DConnexion.h
@@ -79,6 +79,18 @@ protected:
 };
 #endif  // not VRPN_USE_HID
 
+class VRPN_API vrpn_3DConnexionWireless : public vrpn_3DConnexion {
+public:
+	vrpn_3DConnexionWireless(vrpn_HidAcceptor *filter, unsigned num_buttons,
+		const char *name, vrpn_Connection *c = 0,
+		vrpn_uint16 vendor = 0, vrpn_uint16 product = 0);
+	virtual ~vrpn_3DConnexionWireless() {};
+#if defined(VRPN_USE_HID)
+protected:
+	virtual void decodePacket(size_t bytes, vrpn_uint8 *buffer);
+#endif
+};
+
 class VRPN_API vrpn_3DConnexion_Navigator: public vrpn_3DConnexion {
 public:
   vrpn_3DConnexion_Navigator(const char *name, vrpn_Connection *c = 0);
@@ -138,7 +150,15 @@ public:
 protected:
 };
 
-class VRPN_API vrpn_3DConnexion_SpaceMouseWireless : public vrpn_3DConnexion {
+class VRPN_API vrpn_3DConnexion_SpaceMouseProWireless : public vrpn_3DConnexionWireless {
+public:
+  vrpn_3DConnexion_SpaceMouseProWireless(const char *name, vrpn_Connection *c = 0);
+  virtual ~vrpn_3DConnexion_SpaceMouseProWireless() {};
+
+protected:
+};
+
+class VRPN_API vrpn_3DConnexion_SpaceMouseWireless : public vrpn_3DConnexionWireless {
 public:
 	vrpn_3DConnexion_SpaceMouseWireless(const char *name, vrpn_Connection *c = 0);
 	virtual ~vrpn_3DConnexion_SpaceMouseWireless() {};


### PR DESCRIPTION
Added support for 3DConnexion SpaceMouse Pro Wireless. Subclassed vrpn_3DConnexion to provide wireless specific decoding function to cater for differences between 3DConnexion wired and wireless protocols.
