### PR TITLE
Oculus dk2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1094,6 +1094,7 @@ set(VRPN_SERVER_SOURCES
 	vrpn_Tracker_Filter.C
 	vrpn_Tracker_GameTrak.C
 	vrpn_Tracker_GPS.C
+	vrpn_Tracker_IMU.C
 	vrpn_Tracker_isense.C
 	vrpn_Tracker_Isotrak.C
 	vrpn_Tracker_JsonNet.C
@@ -1202,6 +1203,7 @@ set(VRPN_SERVER_PUBLIC_HEADERS
 	vrpn_Tracker_Filter.h
 	vrpn_Tracker_GameTrak.h
 	vrpn_Tracker_GPS.h
+	vrpn_Tracker_IMU.h
 	vrpn_Tracker_isense.h
 	vrpn_Tracker_Isotrak.h
 	vrpn_Tracker_JsonNet.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1074,6 +1074,7 @@ set(VRPN_SERVER_SOURCES
 	vrpn_NationalInstruments.C
 	vrpn_Nidaq.C
 	vrpn_nikon_controls.C
+	vrpn_Oculus.C
 	vrpn_OmegaTemperature.C
 	vrpn_Poser_Analog.C
 	vrpn_Poser_Tek4662.C
@@ -1179,6 +1180,7 @@ set(VRPN_SERVER_PUBLIC_HEADERS
 	vrpn_NationalInstruments.h
 	vrpn_Nidaq.h
 	vrpn_nikon_controls.h
+	vrpn_Oculus.h
 	vrpn_OmegaTemperature.h
 	vrpn_OneEuroFilter.h
 	vrpn_Poser_Analog.h

--- a/Makefile
+++ b/Makefile
@@ -710,6 +710,7 @@ SLIB_FILES =  $(LIB_FILES) \
 	vrpn_Tracker_Filter.C \
 	vrpn_Tracker_GPS.C \
 	vrpn_Tracker_GameTrak.C \
+	vrpn_Tracker_IMU.C \
 	vrpn_Tracker_Isotrak.C \
 	vrpn_Tracker_Liberty.C \
 	vrpn_Tracker_LibertyHS.C \
@@ -802,6 +803,7 @@ SLIB_INCLUDES = $(LIB_INCLUDES) \
 	vrpn_Tracker_Filter.h \
 	vrpn_Tracker_GPS.h \
 	vrpn_Tracker_GameTrak.h \
+	vrpn_Tracker_IMU.h \
 	vrpn_Tracker_Isotrak.h \
 	vrpn_Tracker_Liberty.h \
 	vrpn_Tracker_LibertyHS.h \

--- a/Makefile
+++ b/Makefile
@@ -692,6 +692,7 @@ SLIB_FILES =  $(LIB_FILES) \
 	vrpn_Microsoft_Controller_Raw.C \
 	vrpn_Mouse.C \
 	vrpn_NationalInstruments.C \
+	vrpn_Oculus.C \
 	vrpn_OmegaTemperature.C \
 	vrpn_Poser_Analog.C \
 	vrpn_Poser_Tek4662.C \
@@ -782,6 +783,7 @@ SLIB_INCLUDES = $(LIB_INCLUDES) \
 	vrpn_Microsoft_Controller_Raw.h \
 	vrpn_Mouse.h \
 	vrpn_NationalInstruments.h \
+	vrpn_Oculus.h \
 	vrpn_OmegaTemperature.h \
 	vrpn_OneEuroFilter.h \
 	vrpn_Poser_Analog.h \

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3154,3 +3154,38 @@
 
 #vrpn_IMU_Magnetometer Magnetometer0 100.0
 #*Oculus0 8 0 -1.0 9 0 -1.0 10 0 -1.0
+
+################################################################################
+# Inertial-measurement combiner.  This is a tracker that combines
+# analog values from inertial measurement units and reports orientation
+# and orientation velocity.
+#   One analog device is associated with an accelerometer, one with
+# a rotational linear measurement device, and (optionally) one with
+# a magnetometer.
+#
+# The device exports a Tracker interface with one sensor.
+#
+#   Arguments:
+#	char  name_of_this_device[]
+#	float update_rate_to_send_reports
+#	[two lines follow, describing the accelerometer and rotational inputs:
+#		char	name_of_analog_device[]		(start with * for local)
+#		int	x_channel_of_analog_device
+#		float	x_offset
+#		float	x_scale
+#		int	y_channel_of_analog_device
+#		float	y_offset
+#		float	y_scale
+#		int	z_channel_of_analog_device
+#		float	z_offset
+#		float	z_scale
+#	]
+#	A third following line gives the name of the magnetometer, or the
+#	 name NULL if one is not used.  The name starts with * for a device
+#	 that should be connected to on the same VRPN connection object
+#	 being used for the output.
+
+#vrpn_IMU_SimpleCombiner Tracker0 100.0
+#*Oculus0 2 0 -1.0 3 0 -1.0 4 0 -1.0
+#*Oculus0 5 0 1.0 6 0 1.0 7 0 1.0
+#*Magnetometer0

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3063,17 +3063,17 @@
 # gives orientation information, but no position.
 #
 # This device exports an Analog interface, with the following channels:
-#  0: Uncalibrated temperature (degrees Celsius)
+#  0: Uncalibrated temperature (degrees Celsius?)
 #  1: Time since device power-on (seconds)
 #  2: Uncalibrated accelerometer X component (positive to left ear) (m/s/s)
 #  3: Uncalibrated accelerometer Y component (positive down to feet) (m/s/s)
 #  4: Uncalibrated accelerometer Z component (positive forward) (m/s/s)
-#  5: Uncalibrated gyro X component (positive rotating head up)
-#  6: Uncalibrated gyro Y component (positive rotating head left)
-#  7: Uncalibrated gyro Z component (positive tilting head left)
-#  8: Uncalibrated magnetometer X component
-#  9: Uncalibrated magnetometer Y component
-#  10: Uncalibrated magnetometer Z component
+#  5: Uncalibrated gyro X component (positive rotating head up) (radians/sec?)
+#  6: Uncalibrated gyro Y component (positive rotating head left) (radians/sec?)
+#  7: Uncalibrated gyro Z component (positive tilting head left) (radians/sec?)
+#  8: Uncalibrated Up X component (positive to left ear) (normalize this?)
+#  9: Uncalibrated Up Y component (positive down to feet) (normalize this?)
+#  10: Uncalibrated Up Z component (positive forward) (normalize this?)
 #
 # NOTE: The Oculus drivers may interfere with this raw driver if they are
 #       installed on the system.

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3062,6 +3062,19 @@
 # Oculus DK2 inertial measurement unit.  This is an inertial tracker that 
 # gives orientation information, but no position.
 #
+# This device exports an Analog interface, with the following channels:
+#  0: Uncalibrated temperature (degrees Celsius)
+#  1: Time since device power-on (seconds)
+#  2: Uncalibrated accelerometer X component (positive to left ear) (m/s/s)
+#  3: Uncalibrated accelerometer Y component (positive down to feet) (m/s/s)
+#  4: Uncalibrated accelerometer Z component (positive forward) (m/s/s)
+#  5: Uncalibrated gyro X component (positive rotating head up)
+#  6: Uncalibrated gyro Y component (positive rotating head left)
+#  7: Uncalibrated gyro Z component (positive tilting head left)
+#  8: Uncalibrated magnetometer X component
+#  9: Uncalibrated magnetometer Y component
+#  10: Uncalibrated magnetometer Z component
+#
 # NOTE: The Oculus drivers may interfere with this raw driver if they are
 #       installed on the system.
 #

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3107,7 +3107,7 @@
 #       it will show up as another display.
 #
 # NOTE: The magnetometer ranges on each axis are different, and they are not
-#       symmetric around 0 for any of the axes, so the HKD needs to have been
+#       symmetric around 0 for any of the axes, so the device needs to have been
 #       rotated around a lot to really have an idea of which way is North.  A
 #       tracker based on this value needs to keep track of the extrema.
 #       Also, the magnetic North vector does not point straight along the

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3059,10 +3059,15 @@
 #vrpn_Tracker_OSVRHackerDevKit Tracker0
 
 ################################################################################
-# Oculus DK2 inertial measurement unit.  This is an inertial tracker that 
-# gives orientation information, but no position.
+# There are two versions of this driver, which use the same hardware but it
+# two different modes.
 #
-# This device exports an Analog interface, with the following channels:
+# vrpn_Oculus_DK2_LEDs: Oculus with LEDs enabled, which would enable reading
+#  from its camera to determine position.  Note that the program reading from
+#  the camera will have to put the camera into synchronous mode using a
+#  special command before its results will line up with the LED flashing.
+#
+# The LEDs device exports an Analog interface, with the following channels:
 #  0: Uncalibrated temperature (degrees Celsius?)
 #  1: Time since device power-on (seconds)
 #  2: Uncalibrated accelerometer X component (positive to left ear) (m/s/s)
@@ -3075,6 +3080,10 @@
 #  9: Uncalibrated Up Y component (positive down to feet) (normalize this?)
 #  10: Uncalibrated Up Z component (positive forward) (normalize this?)
 #
+# vrpn_Oculus_DK2_inertial: Oculus DK2 inertial measurement unit only.  This
+#  provides access to the magnetometer readings on the unit and has a different
+#  set of exported values.
+#
 # NOTE: The Oculus drivers may interfere with this raw driver if they are
 #       installed on the system.
 #
@@ -3086,5 +3095,5 @@
 # Arguments:
 #	char	name_of_this_device[]
 
-#vrpn_Oculus_DK2 Analog0
+#vrpn_Oculus_DK2_LEDs Analog0
 

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3116,6 +3116,31 @@
 # Arguments:
 #	char	name_of_this_device[]
 
-#vrpn_Oculus_DK2_inertial Analog0
-#vrpn_Oculus_DK2_LEDs Analog0
+#vrpn_Oculus_DK2_inertial Oculus0
+#vrpn_Oculus_DK2_LEDs Oculus0
+
+################################################################################
+# Magnetometer.  This is an analog that is intended to be used on top of
+# an analog that reads values from a 3-axis magnetometer.
+#   It could be used on top of any analog device, in fact.
+#   This device basically takes in analog signals and puts out analog
+# values that are a unit vector.
+#   One analog channel is associated with each axis (X, Y, Z)
+# For each axis, the value is scaled to a the correct orientation but the
+# magnitude will be normalized and offset to fit the largest range of values
+# ever received for that axis (self-calibrated).
+#   Arguments:
+#	char  name_of_this_device[]
+#	float update_rate_to_send_analog_reports
+#	[three lines follow, one for X Y Z, each with:
+#		char	axis_name[]			(X Y Z in any order)
+#		char	name_of_analog_device[]		(start with * for local)
+#		int	channel_of_analog_device
+#		float	scale
+#	]
+
+#vrpn_IMU_Magnetometer Magnetometer0 100.0
+#X  *Oculus0 8 -1.0
+#Y  *Oculus0 9 -1.0
+#Z  *Oculus0 10 -1.0
 

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3062,6 +3062,23 @@
 # There are two versions of this driver, which use the same hardware but it
 # two different modes.
 #
+# vrpn_Oculus_DK2_inertial: Oculus DK2 inertial measurement unit only.  This
+#  provides access to the magnetometer readings on the unit and has a different
+#  set of exported values.
+#
+# The LEDs device exports an Analog interface, with the following channels:
+#  0: Uncalibrated temperature (degrees Celsius?)
+#  1: Report ID counter that goes up to 65535 and then cycles back to 0
+#  2: Uncalibrated accelerometer X component (positive to left ear) (m/s/s)
+#  3: Uncalibrated accelerometer Y component (positive down to feet) (m/s/s)
+#  4: Uncalibrated accelerometer Z component (positive forward) (m/s/s)
+#  5: Uncalibrated gyro X component (positive rotating head up) (radians/sec?)
+#  6: Uncalibrated gyro Y component (positive rotating head left) (radians/sec?)
+#  7: Uncalibrated gyro Z component (positive tilting head left) (radians/sec?)
+#  8: Uncalibrated Magnetometer X component (positive to left ear) (varied, asymmetric range)
+#  9: Uncalibrated Magnetometer Y component (positive down to feet) (varied, asymmetric range)
+#  10: Uncalibrated Magnetometer Z component (positive forward) (varied, asymmetric range)
+#
 # vrpn_Oculus_DK2_LEDs: Oculus with LEDs enabled, which would enable reading
 #  from its camera to determine position.  Note that the program reading from
 #  the camera will have to put the camera into synchronous mode using a
@@ -3069,20 +3086,17 @@
 #
 # The LEDs device exports an Analog interface, with the following channels:
 #  0: Uncalibrated temperature (degrees Celsius?)
-#  1: Time since device power-on (seconds)
+#  1: Report ID counter that goes up to 65535 and then cycles back to 0
 #  2: Uncalibrated accelerometer X component (positive to left ear) (m/s/s)
 #  3: Uncalibrated accelerometer Y component (positive down to feet) (m/s/s)
 #  4: Uncalibrated accelerometer Z component (positive forward) (m/s/s)
 #  5: Uncalibrated gyro X component (positive rotating head up) (radians/sec?)
 #  6: Uncalibrated gyro Y component (positive rotating head left) (radians/sec?)
 #  7: Uncalibrated gyro Z component (positive tilting head left) (radians/sec?)
-#  8: Uncalibrated Up X component (positive to left ear) (normalize this?)
-#  9: Uncalibrated Up Y component (positive down to feet) (normalize this?)
-#  10: Uncalibrated Up Z component (positive forward) (normalize this?)
-#
-# vrpn_Oculus_DK2_inertial: Oculus DK2 inertial measurement unit only.  This
-#  provides access to the magnetometer readings on the unit and has a different
-#  set of exported values.
+#  8: Uncalibrated Magnetometer X component (positive to left ear) (varied, asymmetric range)
+#  9: Uncalibrated Magnetometer Y component (positive down to feet) (varied, asymmetric range)
+#  10: Uncalibrated Magnetometer Z component (positive forward) (varied, asymmetric range)
+#  11: Time since device power-on (seconds)
 #
 # NOTE: The Oculus drivers may interfere with this raw driver if they are
 #       installed on the system.
@@ -3092,8 +3106,16 @@
 #       in DirectMode, it will not appear as a system display.  If it is not,
 #       it will show up as another display.
 #
+# NOTE: The magnetometer ranges on each axis are different, and they are not
+#       symmetric around 0 for any of the axes, so the HKD needs to have been
+#       rotated around a lot to really have an idea of which way is North.  A
+#       tracker based on this value needs to keep track of the extrema.
+#       Also, the magnetic North vector does not point straight along the
+#       plane of the ground, but rather into the Earth.
+#
 # Arguments:
 #	char	name_of_this_device[]
 
+#vrpn_Oculus_DK2_inertial Analog0
 #vrpn_Oculus_DK2_LEDs Analog0
 

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3129,18 +3129,28 @@
 # For each axis, the value is scaled to a the correct orientation but the
 # magnitude will be normalized and offset to fit the largest range of values
 # ever received for that axis (self-calibrated).
+#   NOTE: The vector will not point perpendicular to gravity.
+#
+# The device exports an Analog interface, with the following channels:
+#  0: X component of normalized, autocalibrated vector
+#  1: Y component of normalized, autocalibrated vector
+#  2: Z component of normalized, autocalibrated vector
+#
 #   Arguments:
 #	char  name_of_this_device[]
 #	float update_rate_to_send_analog_reports
-#	[three lines follow, one for X Y Z, each with:
-#		char	axis_name[]			(X Y Z in any order)
+#	[one lines follows, describing the X Y Z, with:
 #		char	name_of_analog_device[]		(start with * for local)
-#		int	channel_of_analog_device
-#		float	scale
+#		int	x_channel_of_analog_device
+#		float	x_offset					(value ignored)
+#		float	x_scale
+#		int	y_channel_of_analog_device
+#		float	y_offset					(value ignored)
+#		float	y_scale
+#		int	z_channel_of_analog_device
+#		float	z_offset					(value ignored)
+#		float	z_scale
 #	]
 
 #vrpn_IMU_Magnetometer Magnetometer0 100.0
-#X  *Oculus0 8 -1.0
-#Y  *Oculus0 9 -1.0
-#Z  *Oculus0 10 -1.0
-
+#*Oculus0 8 0 -1.0 9 0 -1.0 10 0 -1.0

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3046,3 +3046,32 @@
 #	float	how_far_to_predict_in_seconds
 
 #vrpn_Tracker_DeadReckoning_Rotation	Tracker1	*Tracker0 2 0.0333
+
+################################################################################
+# OSVR Hacker Dev Kit inertial measurement unit.  This is an inertial tracker that 
+# gives orientation information, but no position.  Position values are always
+# 0.  Version 1 of this device sends only poses.  Version 2 also sends velocity
+# reports.
+#
+# Arguments:
+#	char	name_of_this_device[]
+
+#vrpn_Tracker_OSVRHackerDevKit Tracker0
+
+################################################################################
+# Oculus DK2 inertial measurement unit.  This is an inertial tracker that 
+# gives orientation information, but no position.
+#
+# NOTE: The Oculus drivers may interfere with this raw driver if they are
+#       installed on the system.
+#
+# NOTE: A side effect of running this driver is that the HMDI output for the
+#       DK2 will become visible to the system if it is plugged in.  If it is
+#       in DirectMode, it will not appear as a system display.  If it is not,
+#       it will show up as another display.
+#
+# Arguments:
+#	char	name_of_this_device[]
+
+#vrpn_Oculus_DK2 Analog0
+

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -4816,7 +4816,7 @@ int vrpn_Generic_Server_Object::setup_Oculus_DK2_LEDs(char *&pch, char *line, FI
   VRPN_CONFIG_NEXT();
   int ret = sscanf(pch, "%511s", s2);
   if (ret != 1) {
-    fprintf(stderr, "Bad Oculus_DK2 line: %s\n", line);
+    fprintf(stderr, "Bad Oculus_DK2_LEDs line: %s\n", line);
     return -1;
   }
 
@@ -4828,6 +4828,32 @@ int vrpn_Generic_Server_Object::setup_Oculus_DK2_LEDs(char *&pch, char *line, FI
 #ifdef VRPN_USE_HID
   // Open the tracker
   _devices->add(new vrpn_Oculus_DK2_LEDs(s2, connection));
+#else
+  fprintf(stderr,
+    "Oculus_DK2 driver works only with VRPN_USE_HID defined!\n");
+#endif
+  return 0; // successful completion
+}
+
+int vrpn_Generic_Server_Object::setup_Oculus_DK2_inertial(char *&pch, char *line, FILE *)
+{
+  char s2[LINESIZE];
+
+  VRPN_CONFIG_NEXT();
+  int ret = sscanf(pch, "%511s", s2);
+  if (ret != 1) {
+    fprintf(stderr, "Bad Oculus_DK2_inertial line: %s\n", line);
+    return -1;
+  }
+
+  // Open the Oculus DK2
+  if (verbose) {
+    printf("Opening vrpn_Oculus_inertial\n");
+  }
+
+#ifdef VRPN_USE_HID
+  // Open the tracker
+  _devices->add(new vrpn_Oculus_DK2_inertial(s2, connection));
 #else
   fprintf(stderr,
     "Oculus_DK2 driver works only with VRPN_USE_HID defined!\n");
@@ -5390,6 +5416,9 @@ vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
                 }
                 else if (VRPN_ISIT("vrpn_Oculus_DK2_LEDs")) {
                   VRPN_CHECK(setup_Oculus_DK2_LEDs);
+                }
+                else if (VRPN_ISIT("vrpn_Oculus_DK2_inertial")) {
+                  VRPN_CHECK(setup_Oculus_DK2_inertial);
                 }
                 else {                         // Never heard of it
                     sscanf(line, "%511s", s1); // Find out the class name

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -54,6 +54,7 @@
 #include "vrpn_Mouse.h"                    // for vrpn_Button_SerialMouse, etc
 #include "vrpn_NationalInstruments.h"
 #include "vrpn_nikon_controls.h"   // for vrpn_Nikon_Controls
+#include "vrpn_Oculus.h"           // for vrpn_Oculus_DK2
 #include "vrpn_OmegaTemperature.h" // for vrpn_OmegaTemperature
 #include "vrpn_Phantom.h"
 #include "vrpn_Poser_Analog.h"          // for vrpn_Poser_AnalogParam, etc
@@ -4808,6 +4809,32 @@ int vrpn_Generic_Server_Object::setup_Tracker_DeadReckoning_Rotation(char *&pch,
     return 0;
 }
 
+int vrpn_Generic_Server_Object::setup_Oculus_DK2(char *&pch, char *line, FILE *)
+{
+  char s2[LINESIZE];
+
+  VRPN_CONFIG_NEXT();
+  int ret = sscanf(pch, "%511s", s2);
+  if (ret != 1) {
+    fprintf(stderr, "Bad Oculus_DK2 line: %s\n", line);
+    return -1;
+  }
+
+  // Open the Oculus DK2
+  if (verbose) {
+    printf("Opening vrpn_Oculus_DK2\n");
+  }
+
+#ifdef VRPN_USE_HID
+  // Open the tracker
+  _devices->add(new vrpn_Oculus_DK2(s2, connection));
+#else
+  fprintf(stderr,
+    "Oculus_DK2 driver works only with VRPN_USE_HID defined!\n");
+#endif
+  return 0; // successful completion
+}
+
 #undef VRPN_CONFIG_NEXT
 
 vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
@@ -5360,6 +5387,9 @@ vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
                 }
                 else if (VRPN_ISIT("vrpn_Tracker_DeadReckoning_Rotation")) {
                     VRPN_CHECK(setup_Tracker_DeadReckoning_Rotation);
+                }
+                else if (VRPN_ISIT("vrpn_Oculus_DK2")) {
+                  VRPN_CHECK(setup_Oculus_DK2);
                 }
                 else {                         // Never heard of it
                     sscanf(line, "%511s", s1); // Find out the class name

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -4809,7 +4809,7 @@ int vrpn_Generic_Server_Object::setup_Tracker_DeadReckoning_Rotation(char *&pch,
     return 0;
 }
 
-int vrpn_Generic_Server_Object::setup_Oculus_DK2(char *&pch, char *line, FILE *)
+int vrpn_Generic_Server_Object::setup_Oculus_DK2_LEDs(char *&pch, char *line, FILE *)
 {
   char s2[LINESIZE];
 
@@ -4827,7 +4827,7 @@ int vrpn_Generic_Server_Object::setup_Oculus_DK2(char *&pch, char *line, FILE *)
 
 #ifdef VRPN_USE_HID
   // Open the tracker
-  _devices->add(new vrpn_Oculus_DK2(s2, connection));
+  _devices->add(new vrpn_Oculus_DK2_LEDs(s2, connection));
 #else
   fprintf(stderr,
     "Oculus_DK2 driver works only with VRPN_USE_HID defined!\n");
@@ -5388,8 +5388,8 @@ vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
                 else if (VRPN_ISIT("vrpn_Tracker_DeadReckoning_Rotation")) {
                     VRPN_CHECK(setup_Tracker_DeadReckoning_Rotation);
                 }
-                else if (VRPN_ISIT("vrpn_Oculus_DK2")) {
-                  VRPN_CHECK(setup_Oculus_DK2);
+                else if (VRPN_ISIT("vrpn_Oculus_DK2_LEDs")) {
+                  VRPN_CHECK(setup_Oculus_DK2_LEDs);
                 }
                 else {                         // Never heard of it
                     sscanf(line, "%511s", s1); // Find out the class name

--- a/server_src/vrpn_Generic_server_object.h
+++ b/server_src/vrpn_Generic_server_object.h
@@ -8,8 +8,8 @@
 
 class vrpn_MainloopContainer;
 
-const int VRPN_GSO_MAX_NDI_POLARIS_RIGIDBODIES =
-    20; // FIXME find out from the NDI specs if there is a maximum;
+/// @todo find out from the NDI specs if there is a maximum;
+const int VRPN_GSO_MAX_NDI_POLARIS_RIGIDBODIES = 20; 
 
 class VRPN_API vrpn_TAF_axis;
 class VRPN_API vrpn_IMU_Axis_Params;
@@ -163,6 +163,7 @@ protected:
     int setup_Oculus_DK2_LEDs(char *&pch, char *line, FILE *config_file);
     int setup_Oculus_DK2_inertial(char *&pch, char *line, FILE *config_file);
     int setup_IMU_Magnetometer(char *&pch, char *line, FILE *config_file);
+    int setup_IMU_SimpleCombiner(char *&pch, char *line, FILE *config_file);
 
     template <typename T>
     int templated_setup_device_name_only(char *&pch, char *line, FILE *);

--- a/server_src/vrpn_Generic_server_object.h
+++ b/server_src/vrpn_Generic_server_object.h
@@ -158,7 +158,7 @@ protected:
     int setup_YEI_3Space_Sensor(char *&pch, char *line, FILE *config_file);
     int setup_YEI_3Space_Sensor_Wireless(char *&pch, char *line, FILE *config_file);
     int setup_Tracker_ThalmicLabsMyo(char * &pch, char *line, FILE * config_file);
-    int setup_Oculus_DK2(char *&pch, char *line, FILE *config_file);
+    int setup_Oculus_DK2_LEDs(char *&pch, char *line, FILE *config_file);
 
     template <typename T>
     int templated_setup_device_name_only(char *&pch, char *line, FILE *);

--- a/server_src/vrpn_Generic_server_object.h
+++ b/server_src/vrpn_Generic_server_object.h
@@ -158,6 +158,7 @@ protected:
     int setup_YEI_3Space_Sensor(char *&pch, char *line, FILE *config_file);
     int setup_YEI_3Space_Sensor_Wireless(char *&pch, char *line, FILE *config_file);
     int setup_Tracker_ThalmicLabsMyo(char * &pch, char *line, FILE * config_file);
+    int setup_Oculus_DK2(char *&pch, char *line, FILE *config_file);
 
     template <typename T>
     int templated_setup_device_name_only(char *&pch, char *line, FILE *);

--- a/server_src/vrpn_Generic_server_object.h
+++ b/server_src/vrpn_Generic_server_object.h
@@ -12,6 +12,7 @@ const int VRPN_GSO_MAX_NDI_POLARIS_RIGIDBODIES =
     20; // FIXME find out from the NDI specs if there is a maximum;
 
 class VRPN_API vrpn_TAF_axis;
+class VRPN_API vrpn_IMU_Axis_Params;
 class VRPN_API vrpn_PA_axis;
 
 class vrpn_Generic_Server_Object {
@@ -40,6 +41,7 @@ protected:
 
     // Helper functions for the functions below
     int get_AFline(char *line, vrpn_TAF_axis *axis);
+    int get_IMU_Param_Line(char *line, vrpn_IMU_Axis_Params *axis);
     int get_poser_axis_line(FILE *config_file, const char *axis_name,
                             vrpn_PA_axis *axis, vrpn_float64 *min,
                             vrpn_float64 *max);
@@ -160,6 +162,7 @@ protected:
     int setup_Tracker_ThalmicLabsMyo(char * &pch, char *line, FILE * config_file);
     int setup_Oculus_DK2_LEDs(char *&pch, char *line, FILE *config_file);
     int setup_Oculus_DK2_inertial(char *&pch, char *line, FILE *config_file);
+    int setup_IMU_Magnetometer(char *&pch, char *line, FILE *config_file);
 
     template <typename T>
     int templated_setup_device_name_only(char *&pch, char *line, FILE *);

--- a/server_src/vrpn_Generic_server_object.h
+++ b/server_src/vrpn_Generic_server_object.h
@@ -159,6 +159,7 @@ protected:
     int setup_YEI_3Space_Sensor_Wireless(char *&pch, char *line, FILE *config_file);
     int setup_Tracker_ThalmicLabsMyo(char * &pch, char *line, FILE * config_file);
     int setup_Oculus_DK2_LEDs(char *&pch, char *line, FILE *config_file);
+    int setup_Oculus_DK2_inertial(char *&pch, char *line, FILE *config_file);
 
     template <typename T>
     int templated_setup_device_name_only(char *&pch, char *line, FILE *);

--- a/util/cleanupBeforeCommit.sh
+++ b/util/cleanupBeforeCommit.sh
@@ -166,13 +166,6 @@ FindFilesNamedCaseInsensitive() {
     #TrimTrailingWhitespace  # Is this safe to do?
     RemoveExecutablePrivilege
 
-    # Server config file
-    StartProcessingFile server_src/vrpn.cfg
-    RemoveDosEndlines
-    #TrimTrailingWhitespace  # Is this safe to do?
-    CheckForUncommentedLines
-    RemoveExecutablePrivilege
-
     # Clean up all CMake files we control
     for fn in $(FindFilesNamed "CMakeLists.txt") *.cmake cmake/*.cmake submodules/*.cmake submodules/CMakeLists.txt; do
         StartProcessingFile ${fn}
@@ -255,6 +248,11 @@ FindFilesNamedCaseInsensitive() {
         RemoveExecutablePrivilege
     done
 
-
+    # Server config file
+    StartProcessingFile server_src/vrpn.cfg
+    RemoveDosEndlines
+    #TrimTrailingWhitespace  # Is this safe to do?
+    RemoveExecutablePrivilege
+    CheckForUncommentedLines
 )
 

--- a/vrpn.vcproj
+++ b/vrpn.vcproj
@@ -1923,6 +1923,17 @@
 						CompileAs="2"
 					/>
 				</FileConfiguration>
+			<File
+				RelativePath="vrpn_Tracker_IMU.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug|Win32"
 					>
@@ -3043,6 +3054,10 @@
 			</File>
 			<File
 				RelativePath="vrpn_Tracker_AnalogFly.h"
+				>
+			</File>
+			<File
+				RelativePath="vrpn_Tracker_IMU.h"
 				>
 			</File>
 			<File

--- a/vrpn.vcproj
+++ b/vrpn.vcproj
@@ -2253,6 +2253,26 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="vrpn_Oculus.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="vrpn_Tracker_OSVRHackerDevKit.C"
 				>
 				<FileConfiguration
@@ -3087,6 +3107,10 @@
 			</File>
 			<File
 				RelativePath="vrpn_Tracker_NovintFalcon.h"
+				>
+			</File>
+			<File
+				RelativePath="vrpn_Oculus.h"
 				>
 			</File>
 			<File

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -9,7 +9,7 @@ Russell M. Taylor II
 */
 
 // Based on the OSVR hacker dev kit driver by Kevin Godby.
-// Based on Oliver Kreylos' OculusRiftHIDReports.cpp, used with permission.
+// Based on Oliver Kreylos' OculusRiftHIDReports.cpp and OculusRift.cpp.
 
 #include "vrpn_Oculus.h"
 
@@ -31,7 +31,7 @@ vrpn_Oculus_DK2::vrpn_Oculus_DK2(const char *name, vrpn_Connection *c,
 {
   d_keepAliveSeconds = keepAliveSeconds;
 
-  vrpn_Analog::num_channel = 6;
+  vrpn_Analog::num_channel = 11;
   memset(channel, 0, sizeof(channel));
   memset(last, 0, sizeof(last));
 
@@ -45,46 +45,213 @@ vrpn_Oculus_DK2::~vrpn_Oculus_DK2()
   delete m_acceptor;
 }
 
+// Copied from Oliver Kreylos' OculusRift.cpp.
+// Unpacks a 3D vector from 8 bytes
+inline void unpackVector(const vrpn_uint8 raw[8], int vector[3])
+{
+  // @todo Make this also work on big-endian architectures.
+  union // Helper union to assemble 3 or 4 bytes into a signed 32-bit integer
+  {
+    vrpn_uint8 b[4];
+    vrpn_int32 i;
+  } p;
+  struct // Helper structure to sign-extend a 21-bit signed integer value
+  {
+    signed int si : 21;
+  } s;
+
+  /* Assemble the vector's x component: */
+  p.b[0] = raw[2];
+  p.b[1] = raw[1];
+  p.b[2] = raw[0];
+  // p.b[3]=0U; // Not needed because it's masked out below anyway
+  vector[0] = s.si = (p.i >> 3) & 0x001fffff;
+
+  /* Assemble the vector's y component: */
+  p.b[0] = raw[5];
+  p.b[1] = raw[4];
+  p.b[2] = raw[3];
+  p.b[3] = raw[2];
+  vector[1] = s.si = (p.i >> 6) & 0x001fffff;
+
+  /* Assemble the vector's z component: */
+  p.b[0] = raw[7];
+  p.b[1] = raw[6];
+  p.b[2] = raw[5];
+  // p.b[3]=0U; // Not needed because it's masked out below anyway
+  vector[2] = s.si = (p.i >> 1) & 0x001fffff;
+}
+
 // Thank you to Oliver Kreylos for the info needed to write this function.
-// It is based on his OculusRiftHIDReports.cpp, used with permission.
+// It is based on his OculusRiftHIDReports.cpp and OculusRift.cpp.
 void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
-     vrpn_uint8 *buffer)
+  vrpn_uint8 *buffer)
 {
   /* We're getting 64-byte messages of type 11 when the example code
      seems to suggest we want messages of type 1.  Maybe we need to
      set the DK2 into a different mode.
   printf("XXX Got %d bytes\n", static_cast<int>(bytes));
   if (buffer[0] == 0x01) {
-
+    printf("XXX Got report\n");
   } else {
     printf("XXX Unexpected message type: %d\n", buffer[0]);
+    for (size_t i = 0; i < bytes; i++) {
+      printf("%02X ", buffer[i]);
+    }
+    printf("\n");
   }
   */
 
-    // @todo Parse the data and fill in the structures.
+  // Make sure the message length is what we expect.
+  if (bytes != 64) {
+    fprintf(stderr, "vrpn_Oculus_DK2::on_data_received(): Unexpected message length %d, ignoring",
+      static_cast<int>(bytes));
+    return;
+  }
 
-    
-      /* Unpack the message:
-      pktBuffer.setReadPosAbs(0);
-      if (pktBuffer.read<Misc::UInt8>() == 0x01U)
-      {
-        numSamples = pktBuffer.read<Misc::UInt8>();
-        timeStamp = pktBuffer.read<Misc::UInt16>();
-        pktBuffer.skip<Misc::UInt16>(1);
-        temperature = pktBuffer.read<Misc::SInt16>();
-        for (unsigned int sample = 0; sample<numSamples&&sample<3; ++sample)
-        {
-          Misc::UInt8 bytes[16];
-          pktBuffer.read<Misc::UInt8>(bytes, 16);
-          unpackVector(bytes, samples[sample].accel);
-          unpackVector(bytes + 8, samples[sample].gyro);
-        }
-        for (unsigned int sample = numSamples; sample<3; ++sample)
-          pktBuffer.skip<Misc::UInt8>(16);
-        for (int i = 0; i<3; ++i)
-          mag[i] = pktBuffer.read<Misc::SInt16>();
-      }
-      */
+  // Set the timestamp for all reports
+  vrpn_gettimeofday(&d_timestamp, NULL);
+
+#if 0
+  // This was from OculusRift.cpp and seems not to match our readings...
+  // The first two bytes in the message are ignored; they are not present in the
+  // HID report for Oliver's code.  The third byte is 0 and the fourth is the number
+  // of reports (up to 3).
+  size_t num_reports = buffer[3];
+  if (num_reports > 3) { num_reports = 3; }
+  vrpn_int16 magnetometer_raw[3];
+  vrpn_uint8 *magnetometer_base = &buffer[2 + 56];
+  for (size_t i = 0; i < 3; i++) {
+    magnetometer_raw[i] = vrpn_unbuffer_from_little_endian
+      <vrpn_int16, vrpn_uint8>(magnetometer_base);
+  }
+  printf("XXX Magnetometer_raw = %d, %d, %d\n", magnetometer_raw[0], magnetometer_raw[1], magnetometer_raw[2]);
+
+  // Upack the raw reports for the accelerometer and gyroscope
+  // for each available sample.  Then convert each to a scaled
+  // double value and send a report.
+  for (size_t i = 0; i < num_reports; i++) {
+    vrpn_int32 accelerometer_raw[3];
+    vrpn_int32 gyroscope_raw[3];
+    unpackVector(&buffer[2 + 8 + i * 16], accelerometer_raw);
+    unpackVector(&buffer[2 +16 + i * 16], gyroscope_raw);
+
+    // Compute the double values using default calibration.
+    // The accelerometer data goes into analogs 0,1,2.
+    // The gyro data goes into analogs 3,4,5.
+    // The magnetomoter data goes into analogs 6,7,8.
+    const double accelerometer_scale = 0.0001;
+    const double gyroscope_scale = 0.0001;
+    const double magnetometer_scale = 0.0001;
+    channel[0] = accelerometer_raw[0] * accelerometer_scale;
+    channel[1] = accelerometer_raw[1] * accelerometer_scale;
+    channel[2] = accelerometer_raw[2] * accelerometer_scale;
+
+    channel[3] = gyroscope_raw[0] * gyroscope_scale;
+    channel[4] = gyroscope_raw[1] * gyroscope_scale;
+    channel[5] = gyroscope_raw[2] * gyroscope_scale;
+
+    channel[6] = magnetometer_raw[0] * magnetometer_scale;
+    channel[7] = magnetometer_raw[1] * magnetometer_scale;
+    channel[8] = magnetometer_raw[2] * magnetometer_scale;
+    vrpn_Analog::report_changes();
+  }
+#endif
+
+  // Started with the two different layouts in Oliver's code using my DK2
+  // and could not get the required data from it.  I'm getting 64-byte
+  // reports that are somewhat like the 62-byte reports that code has but
+  // not the same.  They seem closer to the code form the OculusRiftHIDReports.cpp
+  // document, but not the same (the last bytes are always 0, and they are supposed
+  // to be the magnetometer, for example).
+  // Looked at how the values changed and tried to figure out how to parse each
+  // part of the file.
+  // The first two bytes in the message are ignored; they are not present in the
+  // HID report for Oliver's code.  The third byte is 0 and the fourth is the number
+  // of reports (up to 2, according to how much space is before the magnetometer
+  // data in the reports we found).
+  size_t num_reports = buffer[3];
+  if (num_reports > 2) { num_reports = 2; }
+
+  // The magnetometer data comes after the space to store two
+  // reports.  We read it first because it seems to apply to
+  // all entries in the file (according to the old parsing code;
+  // it may be that we get one per report now).
+  // @todo Check to see if we get multiple magnetometer reports
+  // when we get multiple other reports (I never see multiple
+  // other reports from my unit).
+  vrpn_uint8 *bufptr;
+  bufptr = &buffer[44];
+#if 1
+  vrpn_int16 magnetometer_raw[3];
+  for (size_t i = 0; i < 3; i++) {
+    magnetometer_raw[i] = vrpn_unbuffer_from_little_endian
+      <vrpn_int16, vrpn_uint8>(bufptr);
+  }
+#else
+  vrpn_int32 magnetometer_raw[3];
+  for (size_t i = 0; i < 3; i++) {
+    unpackVector(bufptr, magnetometer_raw);
+  }
+#endif
+  const double magnetometer_scale = 0.0001;
+  channel[8] = magnetometer_raw[0] * magnetometer_scale;
+  channel[9] = magnetometer_raw[1] * magnetometer_scale;
+  channel[10] = magnetometer_raw[2] * magnetometer_scale;
+  // @todo This is not the magnetometer; it may be parts of two different
+  // readings or it may be some sort of strange up vector that needs to be
+  // normalized, or it may be a vector perpendicular to North.  Check and see
+  // if we have skipped too far ahead and need to be looking at other bytes.
+  printf("XXX Magnetometer = %7.3lf, %7.3lf, %7.3lf\n", channel[8], channel[9], channel[10]);
+
+  // Skip the first four bytes and start parsing the other reports from there.
+  bufptr = &buffer[4];  // Point at the start of the report
+
+  // The next two bytes seem to be an increasing counter that changes by 1 for
+  // every report.
+  vrpn_uint16 report_index, temperature;
+  report_index = vrpn_unbuffer_from_little_endian<vrpn_uint16, vrpn_uint8>(bufptr);
+
+  // The next entry may be temperature, and it may be in hundredths of a degree C
+  const double temperature_scale = 0.01;
+  temperature = vrpn_unbuffer_from_little_endian<vrpn_uint16, vrpn_uint8>(bufptr);
+  channel[0] = temperature * temperature_scale;
+
+  // The next entry is a 4-byte counter with time since device was
+  // powered on in microseconds.  We convert to seconds and report.
+  vrpn_uint32 microseconds;
+  microseconds = vrpn_unbuffer_from_little_endian<vrpn_uint32, vrpn_uint8>(bufptr);
+  channel[1] = microseconds * 1e-6;
+
+  // Unpack a 16-byte accelerometer/gyro report using the routines from
+  // Oliver's code.
+  // Upack the raw reports for the accelerometer and gyroscope
+  // for each available sample.  Then convert each to a scaled
+  // double value and send a report.
+  for (size_t i = 0; i < num_reports; i++) {
+    vrpn_int32 accelerometer_raw[3];
+    vrpn_int32 gyroscope_raw[3];
+    unpackVector(bufptr, accelerometer_raw);
+    bufptr += 8;
+    unpackVector(bufptr, gyroscope_raw);
+    bufptr += 8;
+
+    // Compute the double values using default calibration.
+    // The accelerometer data goes into analogs 0,1,2.
+    // The gyro data goes into analogs 3,4,5.
+    // The magnetomoter data goes into analogs 6,7,8.
+    const double accelerometer_scale = 0.0001;
+    const double gyroscope_scale = 0.0001;
+    channel[2] = accelerometer_raw[0] * accelerometer_scale;
+    channel[3] = accelerometer_raw[1] * accelerometer_scale;
+    channel[4] = accelerometer_raw[2] * accelerometer_scale;
+
+    channel[5] = gyroscope_raw[0] * gyroscope_scale;
+    channel[6] = gyroscope_raw[1] * gyroscope_scale;
+    channel[7] = gyroscope_raw[2] * gyroscope_scale;
+    vrpn_Analog::report_changes();
+  }
+  return;
 }
 
 void vrpn_Oculus_DK2::mainloop()

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -1,11 +1,10 @@
 /** @file	vrpn_Oculus.C
 @brief	Drivers for various Oculus devices.  Initially, just the DK2.
 
-@date	2015
-
-@author
-Russell M. Taylor II
-<russ@reliasolve.com>
+  @date 2015
+  @copyright 2015 ReliaSolve.com
+  @author ReliaSolve.com russ@reliasolve.com
+  @license Standard VRPN license.
 */
 
 // Based on the OSVR hacker dev kit driver by Kevin Godby.

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -9,6 +9,7 @@
 
 // Based on the OSVR hacker dev kit driver by Kevin Godby.
 // Based on Oliver Kreylos' OculusRiftHIDReports.cpp and OculusRift.cpp.
+// He has given permission to release this code under the VRPN license:
 
 #include "vrpn_Oculus.h"
 
@@ -50,7 +51,8 @@ vrpn_Oculus_DK2::~vrpn_Oculus_DK2()
   delete m_acceptor;
 }
 
-// Copied from Oliver Kreylos' OculusRift.cpp.
+// Copied from Oliver Kreylos' OculusRift.cpp; he has given permission
+// to release this code under the VRPN standard license.
 // Unpacks a 3D vector from 8 bytes
 inline void unpackVector(const vrpn_uint8 raw[8], int vector[3])
 {

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -1,0 +1,156 @@
+/** @file	vrpn_Oculus.C
+@brief	Drivers for various Oculus devices.  Initially, just the DK2.
+
+@date	2015
+
+@author
+Russell M. Taylor II
+<russ@reliasolve.com>
+*/
+
+// Based on the OSVR hacker dev kit driver by Kevin Godby.
+// Based on Oliver Kreylos' OculusRiftHIDReports.cpp, used with permission.
+
+#include "vrpn_Oculus.h"
+
+#include "vrpn_BaseClass.h"  // for ::vrpn_TEXT_NORMAL, etc
+
+VRPN_SUPPRESS_EMPTY_OBJECT_WARNING()
+
+#if defined(VRPN_USE_HID)
+
+// USB vendor and product IDs for the models we support
+static const vrpn_uint16 OCULUS_VENDOR = 0x2833;
+static const vrpn_uint16 DK2_PRODUCT = 0x0021;
+
+vrpn_Oculus_DK2::vrpn_Oculus_DK2(const char *name, vrpn_Connection *c,
+  double keepAliveSeconds)
+    : vrpn_Analog(name, c)
+    , vrpn_HidInterface(m_filter =
+      new vrpn_HidProductAcceptor(OCULUS_VENDOR, DK2_PRODUCT))
+{
+  d_keepAliveSeconds = keepAliveSeconds;
+
+  vrpn_Analog::num_channel = 6;
+  memset(channel, 0, sizeof(channel));
+  memset(last, 0, sizeof(last));
+
+  // Set the timestamp
+  vrpn_gettimeofday(&d_timestamp, NULL);
+  d_lastKeepAlive = d_timestamp;
+}
+
+vrpn_Oculus_DK2::~vrpn_Oculus_DK2()
+{
+  delete m_acceptor;
+}
+
+void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
+                                                     vrpn_uint8 *buffer)
+{
+    if (bytes != 32 && bytes != 16) {
+      send_text_message("Unexpected report length", d_timestamp,
+        vrpn_TEXT_WARNING);
+        return;
+    }
+
+    // @todo Parse the data and fill in the structures.
+}
+
+void vrpn_Oculus_DK2::mainloop()
+{
+    vrpn_gettimeofday(&d_timestamp, NULL);
+
+    // See if it has been long enough to send another keep-alive to
+    // the LEDs.
+    if (vrpn_TimevalDurationSeconds(d_timestamp, d_lastKeepAlive) >=
+        d_keepAliveSeconds) {
+      writeKeepAlive();
+      d_lastKeepAlive = d_timestamp;
+    }
+
+    update();
+    server_mainloop();
+}
+
+// Thank you to Oliver Kreylos for the info needed to write this function.
+// It is based on his OculusRiftHIDReports.cpp, used with permission.
+void vrpn_Oculus_DK2::writeLEDControl(
+  bool enable
+  , vrpn_uint16 exposureLength
+  , vrpn_uint16 frameInterval
+  , vrpn_uint16 vSyncOffset
+  , vrpn_uint8 dutyCycle
+  , vrpn_uint8 pattern
+  , bool autoIncrement
+  , bool useCarrier
+  , bool syncInput
+  , bool vSyncLock
+  , bool customPattern
+  , vrpn_uint16 commandId)
+{
+  // Buffer to store our report in.
+  vrpn_uint8 pktBuffer[13];
+
+  /* Pack the packet buffer, using little-endian packing: */
+  vrpn_uint8 *bufptr = pktBuffer;
+  vrpn_int32 buflen = sizeof(pktBuffer);
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, vrpn_uint8(0x0cU));
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, commandId);
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, pattern);
+  vrpn_uint8 flags = 0x00U;
+  if (enable) {
+    flags |= 0x01U;
+  }
+  if (autoIncrement) {
+    flags |= 0x02U;
+  }
+  if (useCarrier) {
+    flags |= 0x04U;
+  }
+  if (syncInput) {
+    flags |= 0x08U;
+  }
+  if (vSyncLock) {
+    flags |= 0x10U;
+  }
+  if (customPattern) {
+    flags |= 0x20U;
+  }
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, flags);
+  vrpn_buffer_to_little_endian(&bufptr, &buflen,
+    vrpn_uint8(0x0cU)); // Reserved byte
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, exposureLength);
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, frameInterval);
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, vSyncOffset);
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, dutyCycle);
+
+  /* Write the LED control feature report: */
+  send_feature_report(sizeof(pktBuffer), pktBuffer);
+}
+
+// Thank you to Oliver Kreylos for the info needed to write this function.
+// It is based on his OculusRiftHIDReports.cpp, used with permission.
+void vrpn_Oculus_DK2::writeKeepAlive(
+  bool keepLEDs
+  , vrpn_uint16 interval
+  , vrpn_uint16 commandId)
+{
+  // Buffer to store our report in.
+  vrpn_uint8 pktBuffer[6];
+
+  /* Pack the packet buffer, using little-endian packing: */
+  vrpn_uint8 *bufptr = pktBuffer;
+  vrpn_int32 buflen = sizeof(pktBuffer);
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, vrpn_uint8(0x11U));
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, commandId);
+  vrpn_uint8 flags = keepLEDs ? 0x0bU : 0x01U;
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, flags);
+  vrpn_buffer_to_little_endian(&bufptr, &buflen, interval);
+
+  /* Write the LED control feature report: */
+  send_feature_report(sizeof(pktBuffer), pktBuffer);
+}
+
+
+#endif

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -125,12 +125,12 @@ void vrpn_Oculus_DK2::parse_message_type_1(std::size_t bytes,
     magnetometer_raw[i] = vrpn_unbuffer_from_little_endian
       <vrpn_int16, vrpn_uint8>(magnetometer_ptr);
   }
-  // Invert these to make the magnetometer direction match
+  // Invert X and Y to make the magnetometer direction match
   // the sign of the gravity vector.
-  const double magnetometer_scale = -0.0001;
+  const double magnetometer_scale = 0.0001;
   channel[8] = -magnetometer_raw[0] * magnetometer_scale;
   channel[9] = -magnetometer_raw[1] * magnetometer_scale;
-  channel[10] = -magnetometer_raw[2] * magnetometer_scale;
+  channel[10] = magnetometer_raw[2] * magnetometer_scale;
 
   // Unpack a 16-byte accelerometer/gyro report using the routines from
   // Oliver's code.
@@ -276,7 +276,8 @@ void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
   vrpn_gettimeofday(&d_timestamp, NULL);
 
   // Make sure the message length and type is what we expect.
-  if (bytes != 64) {
+  // We get 64-byte responses on Windows and 62-byte responses on the mac.
+  if ( (bytes != 62) && (bytes != 64) ) {
     fprintf(stderr, "vrpn_Oculus_DK2::on_data_received(): Unexpected message length %d, ignoring\n",
       static_cast<int>(bytes));
     return;

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -45,16 +45,46 @@ vrpn_Oculus_DK2::~vrpn_Oculus_DK2()
   delete m_acceptor;
 }
 
+// Thank you to Oliver Kreylos for the info needed to write this function.
+// It is based on his OculusRiftHIDReports.cpp, used with permission.
 void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
-                                                     vrpn_uint8 *buffer)
+     vrpn_uint8 *buffer)
 {
-    if (bytes != 32 && bytes != 16) {
-      send_text_message("Unexpected report length", d_timestamp,
-        vrpn_TEXT_WARNING);
-        return;
-    }
+  /* We're getting 64-byte messages of type 11 when the example code
+     seems to suggest we want messages of type 1.  Maybe we need to
+     set the DK2 into a different mode.
+  printf("XXX Got %d bytes\n", static_cast<int>(bytes));
+  if (buffer[0] == 0x01) {
+
+  } else {
+    printf("XXX Unexpected message type: %d\n", buffer[0]);
+  }
+  */
 
     // @todo Parse the data and fill in the structures.
+
+    
+      /* Unpack the message:
+      pktBuffer.setReadPosAbs(0);
+      if (pktBuffer.read<Misc::UInt8>() == 0x01U)
+      {
+        numSamples = pktBuffer.read<Misc::UInt8>();
+        timeStamp = pktBuffer.read<Misc::UInt16>();
+        pktBuffer.skip<Misc::UInt16>(1);
+        temperature = pktBuffer.read<Misc::SInt16>();
+        for (unsigned int sample = 0; sample<numSamples&&sample<3; ++sample)
+        {
+          Misc::UInt8 bytes[16];
+          pktBuffer.read<Misc::UInt8>(bytes, 16);
+          unpackVector(bytes, samples[sample].accel);
+          unpackVector(bytes + 8, samples[sample].gyro);
+        }
+        for (unsigned int sample = numSamples; sample<3; ++sample)
+          pktBuffer.skip<Misc::UInt8>(16);
+        for (int i = 0; i<3; ++i)
+          mag[i] = pktBuffer.read<Misc::SInt16>();
+      }
+      */
 }
 
 void vrpn_Oculus_DK2::mainloop()

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -23,13 +23,15 @@ VRPN_SUPPRESS_EMPTY_OBJECT_WARNING()
 static const vrpn_uint16 OCULUS_VENDOR = 0x2833;
 static const vrpn_uint16 DK2_PRODUCT = 0x0021;
 
-vrpn_Oculus_DK2::vrpn_Oculus_DK2(const char *name, vrpn_Connection *c,
+vrpn_Oculus_DK2::vrpn_Oculus_DK2(bool enableLEDs,
+  const char *name, vrpn_Connection *c,
   double keepAliveSeconds)
     : vrpn_Analog(name, c)
     , vrpn_HidInterface(m_filter =
       new vrpn_HidProductAcceptor(OCULUS_VENDOR, DK2_PRODUCT))
 {
   d_keepAliveSeconds = keepAliveSeconds;
+  d_enableLEDs = enableLEDs;
 
   vrpn_Analog::num_channel = 11;
   memset(channel, 0, sizeof(channel));
@@ -235,8 +237,7 @@ void vrpn_Oculus_DK2::mainloop()
 // Thank you to Oliver Kreylos for the info needed to write this function.
 // It is based on his OculusRiftHIDReports.cpp, used with permission.
 void vrpn_Oculus_DK2::writeKeepAlive(
-  bool keepLEDs
-  , vrpn_uint16 interval
+  vrpn_uint16 interval
   , vrpn_uint16 commandId)
 {
   // Buffer to store our report in.
@@ -247,7 +248,7 @@ void vrpn_Oculus_DK2::writeKeepAlive(
   vrpn_int32 buflen = sizeof(pktBuffer);
   vrpn_buffer_to_little_endian(&bufptr, &buflen, vrpn_uint8(0x11U));
   vrpn_buffer_to_little_endian(&bufptr, &buflen, commandId);
-  vrpn_uint8 flags = keepLEDs ? 0x0bU : 0x01U;
+  vrpn_uint8 flags = d_enableLEDs ? 0x0bU : 0x01U;
   vrpn_buffer_to_little_endian(&bufptr, &buflen, flags);
   vrpn_buffer_to_little_endian(&bufptr, &buflen, interval);
 

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -84,80 +84,10 @@ inline void unpackVector(const vrpn_uint8 raw[8], int vector[3])
 
 // Thank you to Oliver Kreylos for the info needed to write this function.
 // It is based on his OculusRiftHIDReports.cpp and OculusRift.cpp.
-void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
+
+void vrpn_Oculus_DK2::parse_message_type_11(std::size_t bytes,
   vrpn_uint8 *buffer)
 {
-  /* We're getting 64-byte messages of type 11 when the example code
-     seems to suggest we want messages of type 1.  Maybe we need to
-     set the DK2 into a different mode.
-  printf("XXX Got %d bytes\n", static_cast<int>(bytes));
-  if (buffer[0] == 0x01) {
-    printf("XXX Got report\n");
-  } else {
-    printf("XXX Unexpected message type: %d\n", buffer[0]);
-    for (size_t i = 0; i < bytes; i++) {
-      printf("%02X ", buffer[i]);
-    }
-    printf("\n");
-  }
-  */
-
-  // Make sure the message length is what we expect.
-  if (bytes != 64) {
-    fprintf(stderr, "vrpn_Oculus_DK2::on_data_received(): Unexpected message length %d, ignoring",
-      static_cast<int>(bytes));
-    return;
-  }
-
-  // Set the timestamp for all reports
-  vrpn_gettimeofday(&d_timestamp, NULL);
-
-#if 0
-  // This was from OculusRift.cpp and seems not to match our readings...
-  // The first two bytes in the message are ignored; they are not present in the
-  // HID report for Oliver's code.  The third byte is 0 and the fourth is the number
-  // of reports (up to 3).
-  size_t num_reports = buffer[3];
-  if (num_reports > 3) { num_reports = 3; }
-  vrpn_int16 magnetometer_raw[3];
-  vrpn_uint8 *magnetometer_base = &buffer[2 + 56];
-  for (size_t i = 0; i < 3; i++) {
-    magnetometer_raw[i] = vrpn_unbuffer_from_little_endian
-      <vrpn_int16, vrpn_uint8>(magnetometer_base);
-  }
-  printf("XXX Magnetometer_raw = %d, %d, %d\n", magnetometer_raw[0], magnetometer_raw[1], magnetometer_raw[2]);
-
-  // Upack the raw reports for the accelerometer and gyroscope
-  // for each available sample.  Then convert each to a scaled
-  // double value and send a report.
-  for (size_t i = 0; i < num_reports; i++) {
-    vrpn_int32 accelerometer_raw[3];
-    vrpn_int32 gyroscope_raw[3];
-    unpackVector(&buffer[2 + 8 + i * 16], accelerometer_raw);
-    unpackVector(&buffer[2 +16 + i * 16], gyroscope_raw);
-
-    // Compute the double values using default calibration.
-    // The accelerometer data goes into analogs 0,1,2.
-    // The gyro data goes into analogs 3,4,5.
-    // The magnetomoter data goes into analogs 6,7,8.
-    const double accelerometer_scale = 0.0001;
-    const double gyroscope_scale = 0.0001;
-    const double magnetometer_scale = 0.0001;
-    channel[0] = accelerometer_raw[0] * accelerometer_scale;
-    channel[1] = accelerometer_raw[1] * accelerometer_scale;
-    channel[2] = accelerometer_raw[2] * accelerometer_scale;
-
-    channel[3] = gyroscope_raw[0] * gyroscope_scale;
-    channel[4] = gyroscope_raw[1] * gyroscope_scale;
-    channel[5] = gyroscope_raw[2] * gyroscope_scale;
-
-    channel[6] = magnetometer_raw[0] * magnetometer_scale;
-    channel[7] = magnetometer_raw[1] * magnetometer_scale;
-    channel[8] = magnetometer_raw[2] * magnetometer_scale;
-    vrpn_Analog::report_changes();
-  }
-#endif
-
   // Started with the two different layouts in Oliver's code using my DK2
   // and could not get the required data from it.  I'm getting 64-byte
   // reports that are somewhat like the 62-byte reports that code has but
@@ -173,42 +103,23 @@ void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
   size_t num_reports = buffer[3];
   if (num_reports > 2) { num_reports = 2; }
 
-  // The magnetometer data comes after the space to store two
-  // reports.  We read it first because it seems to apply to
-  // all entries in the file (according to the old parsing code;
-  // it may be that we get one per report now).
-  // @todo Check to see if we get multiple magnetometer reports
+  // @todo Check to see if we get multiple up reports
   // when we get multiple other reports (I never see multiple
   // other reports from my unit).
-  vrpn_uint8 *bufptr;
-  bufptr = &buffer[44];
-#if 1
-  vrpn_int16 magnetometer_raw[3];
-  for (size_t i = 0; i < 3; i++) {
-    magnetometer_raw[i] = vrpn_unbuffer_from_little_endian
-      <vrpn_int16, vrpn_uint8>(bufptr);
+  if (num_reports == 2) {
+    static bool printed = false;
+    if (!printed) {
+      fprintf(stderr, "vrpn_Oculus_DK2::on_data_received: Got 2 reports; check accuracy of "
+        "the up vector on the second and either replace with the first if it is zero or "
+        " remove this print statement from the code if it works.\n");
+      printed = true;
+    }
   }
-#else
-  vrpn_int32 magnetometer_raw[3];
-  for (size_t i = 0; i < 3; i++) {
-    unpackVector(bufptr, magnetometer_raw);
-  }
-#endif
-  const double magnetometer_scale = 0.0001;
-  channel[8] = magnetometer_raw[0] * magnetometer_scale;
-  channel[9] = magnetometer_raw[1] * magnetometer_scale;
-  channel[10] = magnetometer_raw[2] * magnetometer_scale;
-  // @todo This is not the magnetometer; it may be parts of two different
-  // readings or it may be some sort of strange up vector that needs to be
-  // normalized, or it may be a vector perpendicular to North.  Check and see
-  // if we have skipped too far ahead and need to be looking at other bytes.
-  printf("XXX Magnetometer = %7.3lf, %7.3lf, %7.3lf\n", channel[8], channel[9], channel[10]);
-
   // Skip the first four bytes and start parsing the other reports from there.
-  bufptr = &buffer[4];  // Point at the start of the report
+  vrpn_uint8 *bufptr = &buffer[4];  // Point at the start of the report
 
-  // The next two bytes seem to be an increasing counter that changes by 1 for
-  // every report.
+                                    // The next two bytes seem to be an increasing counter that changes by 1 for
+                                    // every report.
   vrpn_uint16 report_index, temperature;
   report_index = vrpn_unbuffer_from_little_endian<vrpn_uint16, vrpn_uint8>(bufptr);
 
@@ -224,7 +135,11 @@ void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
   channel[1] = microseconds * 1e-6;
 
   // Unpack a 16-byte accelerometer/gyro report using the routines from
-  // Oliver's code.
+  // Oliver's code.  Also what was expected to be a gravity vector, but
+  // which behaves like an Up vector perpendicular to the North vector.
+  // but which has different magnitudes for positive vs. negative on each
+  // axis, and different magnitudes between axes.  It does not vary as
+  // you shake the unit, whereas the accelerometer data does.
   // Upack the raw reports for the accelerometer and gyroscope
   // for each available sample.  Then convert each to a scaled
   // double value and send a report.
@@ -249,9 +164,56 @@ void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
     channel[5] = gyroscope_raw[0] * gyroscope_scale;
     channel[6] = gyroscope_raw[1] * gyroscope_scale;
     channel[7] = gyroscope_raw[2] * gyroscope_scale;
+
+    // The up-vector data comes after the space to store two
+    // reports.  We don't know if there are two of them when
+    // there are two reports, but there is space in the report
+    // for it, so we try to decode two of them.
+    vrpn_uint8 *up_ptr = &buffer[44 + 8 * i];
+    vrpn_int16 up_raw[3];
+    for (size_t i = 0; i < 3; i++) {
+      up_raw[i] = vrpn_unbuffer_from_little_endian
+        <vrpn_int16, vrpn_uint8>(up_ptr);
+    }
+    const double up_scale = 0.0001;
+    channel[8] = up_raw[0] * up_scale;
+    channel[9] = up_raw[1] * up_scale;
+    channel[10] = up_raw[2] * up_scale;
+
     vrpn_Analog::report_changes();
   }
-  return;
+}
+
+void vrpn_Oculus_DK2::on_data_received(std::size_t bytes,
+  vrpn_uint8 *buffer)
+{
+  /* For debugging
+  printf("Got %d bytes:\n", static_cast<int>(bytes));
+  for (size_t i = 0; i < bytes; i++) {
+    printf("%02X ", buffer[i]);
+  }
+  printf("\n");
+  */
+
+  // Set the timestamp for all reports
+  vrpn_gettimeofday(&d_timestamp, NULL);
+
+  // Make sure the message length and type is what we expect.
+  if (bytes != 64) {
+    fprintf(stderr, "vrpn_Oculus_DK2::on_data_received(): Unexpected message length %d, ignoring\n",
+      static_cast<int>(bytes));
+    return;
+  }
+
+  // Call the appropriate parser
+  switch (buffer[0]) {
+  case 11:
+    parse_message_type_11(bytes, buffer);
+    break;
+  default:
+    fprintf(stderr, "vrpn_Oculus_DK2::on_data_received(): Unexpected message type %d, ignoring\n",
+      buffer[0]);
+  }
 }
 
 void vrpn_Oculus_DK2::mainloop()
@@ -268,62 +230,6 @@ void vrpn_Oculus_DK2::mainloop()
 
     update();
     server_mainloop();
-}
-
-// Thank you to Oliver Kreylos for the info needed to write this function.
-// It is based on his OculusRiftHIDReports.cpp, used with permission.
-void vrpn_Oculus_DK2::writeLEDControl(
-  bool enable
-  , vrpn_uint16 exposureLength
-  , vrpn_uint16 frameInterval
-  , vrpn_uint16 vSyncOffset
-  , vrpn_uint8 dutyCycle
-  , vrpn_uint8 pattern
-  , bool autoIncrement
-  , bool useCarrier
-  , bool syncInput
-  , bool vSyncLock
-  , bool customPattern
-  , vrpn_uint16 commandId)
-{
-  // Buffer to store our report in.
-  vrpn_uint8 pktBuffer[13];
-
-  /* Pack the packet buffer, using little-endian packing: */
-  vrpn_uint8 *bufptr = pktBuffer;
-  vrpn_int32 buflen = sizeof(pktBuffer);
-  vrpn_buffer_to_little_endian(&bufptr, &buflen, vrpn_uint8(0x0cU));
-  vrpn_buffer_to_little_endian(&bufptr, &buflen, commandId);
-  vrpn_buffer_to_little_endian(&bufptr, &buflen, pattern);
-  vrpn_uint8 flags = 0x00U;
-  if (enable) {
-    flags |= 0x01U;
-  }
-  if (autoIncrement) {
-    flags |= 0x02U;
-  }
-  if (useCarrier) {
-    flags |= 0x04U;
-  }
-  if (syncInput) {
-    flags |= 0x08U;
-  }
-  if (vSyncLock) {
-    flags |= 0x10U;
-  }
-  if (customPattern) {
-    flags |= 0x20U;
-  }
-  vrpn_buffer_to_little_endian(&bufptr, &buflen, flags);
-  vrpn_buffer_to_little_endian(&bufptr, &buflen,
-    vrpn_uint8(0x0cU)); // Reserved byte
-  vrpn_buffer_to_little_endian(&bufptr, &buflen, exposureLength);
-  vrpn_buffer_to_little_endian(&bufptr, &buflen, frameInterval);
-  vrpn_buffer_to_little_endian(&bufptr, &buflen, vSyncOffset);
-  vrpn_buffer_to_little_endian(&bufptr, &buflen, dutyCycle);
-
-  /* Write the LED control feature report: */
-  send_feature_report(sizeof(pktBuffer), pktBuffer);
 }
 
 // Thank you to Oliver Kreylos for the info needed to write this function.
@@ -348,6 +254,5 @@ void vrpn_Oculus_DK2::writeKeepAlive(
   /* Write the LED control feature report: */
   send_feature_report(sizeof(pktBuffer), pktBuffer);
 }
-
 
 #endif

--- a/vrpn_Oculus.C
+++ b/vrpn_Oculus.C
@@ -126,12 +126,12 @@ void vrpn_Oculus_DK2::parse_message_type_1(std::size_t bytes,
     magnetometer_raw[i] = vrpn_unbuffer_from_little_endian
       <vrpn_int16, vrpn_uint8>(magnetometer_ptr);
   }
-  // Invert X and Y to make the magnetometer direction match
+  // Invert all axes to make the magnetometer direction match
   // the sign of the gravity vector.
   const double magnetometer_scale = 0.0001;
   channel[8] = -magnetometer_raw[0] * magnetometer_scale;
   channel[9] = -magnetometer_raw[1] * magnetometer_scale;
-  channel[10] = magnetometer_raw[2] * magnetometer_scale;
+  channel[10] = -magnetometer_raw[2] * magnetometer_scale;
 
   // Unpack a 16-byte accelerometer/gyro report using the routines from
   // Oliver's code.

--- a/vrpn_Oculus.h
+++ b/vrpn_Oculus.h
@@ -41,7 +41,17 @@ public:
 protected:
   vrpn_HidAcceptor *m_filter;
 
-  /// Extracts the sensor values from each report.
+  //-------------------------------------------------------------
+  // Parsers for different report types.  The DK2 sends type-1
+  // reports in response to inertial-only keep-alive messages
+  // and type-11 reports in response to LED-enabled keep-alive
+  // messages.
+
+  /// Parse and send reports for type-11 message
+  void parse_message_type_11(std::size_t bytes, vrpn_uint8 *buffer);
+
+  /// Extracts the sensor values from each report and calls the
+  /// appropriate parser.
   void on_data_received(std::size_t bytes, vrpn_uint8 *buffer);
 
   /// Timestamp updated during mainloop()
@@ -51,26 +61,10 @@ protected:
   double d_keepAliveSeconds;
   struct timeval d_lastKeepAlive;
 
-  // Send an LED control feature report. The enable flag tells
-  // whether to turn on the LEDs (true) or not.
-  void
-    writeLEDControl(bool enable = true, vrpn_uint16 exposureLength = 350,
-      vrpn_uint16 frameInterval = 16666
-      , vrpn_uint16 vSyncOffset = 0
-      , vrpn_uint8 dutyCycle = 127 //< 255 = 100% brightness
-      , vrpn_uint8 pattern = 1
-      , bool autoIncrement = true
-      , bool useCarrier = true
-      , bool syncInput = false
-      , bool vSyncLock = false
-      , bool customPattern = false
-      , vrpn_uint16 commandId = 0 //< Should always be zero
-      );
-
   // Send a KeepAlive feature report to the DK2.  This needs to be sent
   // every keepAliveSeconds to keep the LEDs going.
   void writeKeepAlive(
-    bool keepLEDs = true //< Keep LEDs going, or only IMU?
+    bool keepLEDs = true //< Keep LEDs going, or only IMU? (Changes report type)
     , vrpn_uint16 interval = 10000 //< KeepAlive time in milliseconds
     , vrpn_uint16 commandId = 0 //< Should always be zero
     );

--- a/vrpn_Oculus.h
+++ b/vrpn_Oculus.h
@@ -2,10 +2,9 @@
 	@brief	Header for various Oculus devices.  Initially, just the DK2.
 
 	@date	2015
-
-	@author
-	Russell M. Taylor II
-	<russ@reliasolve.com>
+  @copyright 2015 ReliaSolve.com
+  @author ReliaSolve.com russ@reliasolve.com
+  @license Standard VRPN license.
 */
 
 // Based on the OSVR hacker dev kit driver by Kevin Godby.

--- a/vrpn_Oculus.h
+++ b/vrpn_Oculus.h
@@ -9,7 +9,7 @@
 */
 
 // Based on the OSVR hacker dev kit driver by Kevin Godby.
-// Based on Oliver Kreylos' OculusRiftHIDReports.cpp, used with permission.
+// Based on Oliver Kreylos' OculusRiftHIDReports.cpp.
 
 #pragma once
 

--- a/vrpn_Oculus.h
+++ b/vrpn_Oculus.h
@@ -48,6 +48,9 @@ protected:
   // and type-11 reports in response to LED-enabled keep-alive
   // messages.
 
+  /// Parse and send reports for type-1 message
+  void parse_message_type_1(std::size_t bytes, vrpn_uint8 *buffer);
+
   /// Parse and send reports for type-11 message
   void parse_message_type_11(std::size_t bytes, vrpn_uint8 *buffer);
 
@@ -72,6 +75,21 @@ protected:
 };
 
 /// @brief Oculus Rift DK2 head-mounted display (inertial measurement unit only)
+class VRPN_API vrpn_Oculus_DK2_inertial : public vrpn_Oculus_DK2 {
+public:
+  /**
+  * @brief Constructor
+  *
+  * @param name Name of this device.
+  * @param c Optional vrpn_Connection pointer to use as our connection.
+  * @param keepAliveSeconds How often to re-trigger the LED flashing
+  */
+  vrpn_Oculus_DK2_inertial(const char *name, vrpn_Connection *c = NULL,
+    double keepAliveSeconds = 9.0)
+    : vrpn_Oculus_DK2(false, name, c, keepAliveSeconds) {};
+};
+
+/// @brief Oculus Rift DK2 head-mounted display (LEDs enabled)
 class VRPN_API vrpn_Oculus_DK2_LEDs : public vrpn_Oculus_DK2 {
 public:
   /**

--- a/vrpn_Oculus.h
+++ b/vrpn_Oculus.h
@@ -1,0 +1,79 @@
+/** @file	vrpn_Oculus.h
+	@brief	Header for various Oculus devices.  Initially, just the DK2.
+
+	@date	2015
+
+	@author
+	Russell M. Taylor II
+	<russ@reliasolve.com>
+*/
+
+// Based on the OSVR hacker dev kit driver by Kevin Godby.
+// Based on Oliver Kreylos' OculusRiftHIDReports.cpp, used with permission.
+
+#pragma once
+
+#include "vrpn_HumanInterface.h"
+#include "vrpn_Analog.h"
+
+#if defined(VRPN_USE_HID)
+
+/// @brief Oculus Rift DK2 head-mounted display (inertial measurement unit only)
+class VRPN_API vrpn_Oculus_DK2 : public vrpn_Analog, protected vrpn_HidInterface {
+public:
+    /**
+     * @brief Constructor.
+     *
+     * @param name Name of this device.
+     * @param c Optional vrpn_Connection pointer to use as our connection.
+     * @param keepAliveSeconds How often to re-trigger the LED flashing
+     */
+    vrpn_Oculus_DK2(const char *name, vrpn_Connection *c = NULL,
+      double keepAliveSeconds = 9.0);
+
+    /**
+     * @brief Destructor.
+     */
+    virtual ~vrpn_Oculus_DK2();
+
+    virtual void mainloop();
+
+protected:
+  vrpn_HidAcceptor *m_filter;
+
+  /// Extracts the sensor values from each report.
+  void on_data_received(std::size_t bytes, vrpn_uint8 *buffer);
+
+  /// Timestamp updated during mainloop()
+  struct timeval d_timestamp;
+
+  /// How often to send the keepAlive message to trigger the LEDs
+  double d_keepAliveSeconds;
+  struct timeval d_lastKeepAlive;
+
+  // Send an LED control feature report. The enable flag tells
+  // whether to turn on the LEDs (true) or not.
+  void
+    writeLEDControl(bool enable = true, vrpn_uint16 exposureLength = 350,
+      vrpn_uint16 frameInterval = 16666
+      , vrpn_uint16 vSyncOffset = 0
+      , vrpn_uint8 dutyCycle = 127 //< 255 = 100% brightness
+      , vrpn_uint8 pattern = 1
+      , bool autoIncrement = true
+      , bool useCarrier = true
+      , bool syncInput = false
+      , bool vSyncLock = false
+      , bool customPattern = false
+      , vrpn_uint16 commandId = 0 //< Should always be zero
+      );
+
+  // Send a KeepAlive feature report to the DK2.  This needs to be sent
+  // every keepAliveSeconds to keep the LEDs going.
+  void writeKeepAlive(
+    bool keepLEDs = true //< Keep LEDs going, or only IMU?
+    , vrpn_uint16 interval = 10000 //< KeepAlive time in milliseconds
+    , vrpn_uint16 commandId = 0 //< Should always be zero
+    );
+};
+
+#endif // VRPN_USE_HID

--- a/vrpn_Oculus.h
+++ b/vrpn_Oculus.h
@@ -18,19 +18,10 @@
 
 #if defined(VRPN_USE_HID)
 
-/// @brief Oculus Rift DK2 head-mounted display (inertial measurement unit only)
+/// @brief Oculus Rift DK2 head-mounted display base class for both intertial-
+/// only and LED-enabled version.
 class VRPN_API vrpn_Oculus_DK2 : public vrpn_Analog, protected vrpn_HidInterface {
 public:
-    /**
-     * @brief Constructor.
-     *
-     * @param name Name of this device.
-     * @param c Optional vrpn_Connection pointer to use as our connection.
-     * @param keepAliveSeconds How often to re-trigger the LED flashing
-     */
-    vrpn_Oculus_DK2(const char *name, vrpn_Connection *c = NULL,
-      double keepAliveSeconds = 9.0);
-
     /**
      * @brief Destructor.
      */
@@ -39,6 +30,16 @@ public:
     virtual void mainloop();
 
 protected:
+  /**
+  * @brief Protected constructor so you can't instantiate this base class.
+  *
+  * @param name Name of this device.
+  * @param c Optional vrpn_Connection pointer to use as our connection.
+  * @param keepAliveSeconds How often to re-trigger the LED flashing
+  */
+  vrpn_Oculus_DK2(bool enableLEDs, const char *name, vrpn_Connection *c = NULL,
+    double keepAliveSeconds = 9.0);
+
   vrpn_HidAcceptor *m_filter;
 
   //-------------------------------------------------------------
@@ -58,16 +59,31 @@ protected:
   struct timeval d_timestamp;
 
   /// How often to send the keepAlive message to trigger the LEDs
+  bool d_enableLEDs;
   double d_keepAliveSeconds;
   struct timeval d_lastKeepAlive;
 
   // Send a KeepAlive feature report to the DK2.  This needs to be sent
   // every keepAliveSeconds to keep the LEDs going.
   void writeKeepAlive(
-    bool keepLEDs = true //< Keep LEDs going, or only IMU? (Changes report type)
-    , vrpn_uint16 interval = 10000 //< KeepAlive time in milliseconds
+    vrpn_uint16 interval = 10000 //< KeepAlive time in milliseconds
     , vrpn_uint16 commandId = 0 //< Should always be zero
     );
+};
+
+/// @brief Oculus Rift DK2 head-mounted display (inertial measurement unit only)
+class VRPN_API vrpn_Oculus_DK2_LEDs : public vrpn_Oculus_DK2 {
+public:
+  /**
+  * @brief Constructor
+  *
+  * @param name Name of this device.
+  * @param c Optional vrpn_Connection pointer to use as our connection.
+  * @param keepAliveSeconds How often to re-trigger the LED flashing
+  */
+  vrpn_Oculus_DK2_LEDs(const char *name, vrpn_Connection *c = NULL,
+    double keepAliveSeconds = 9.0)
+    : vrpn_Oculus_DK2(true, name, c, keepAliveSeconds) {};
 };
 
 #endif // VRPN_USE_HID

--- a/vrpn_Tracker_AnalogFly.h
+++ b/vrpn_Tracker_AnalogFly.h
@@ -112,15 +112,8 @@ class VRPN_API vrpn_Tracker_AnalogFly : public vrpn_Tracker {
     virtual ~vrpn_Tracker_AnalogFly (void);
 
     virtual void mainloop ();
-    virtual void reset (void);
-
-    void update (q_matrix_type &);
-
-    static void VRPN_CALLBACK handle_joystick (void *, const vrpn_ANALOGCB);
-    static int VRPN_CALLBACK handle_newConnection (void *, vrpn_HANDLERPARAM);
 
   protected:
-
     double	    d_update_interval;	//< How long to wait between sends
     struct timeval  d_prevtime;		//< Time of the previous report
     bool	    d_absolute;		//< Report absolute (vs. differential)?
@@ -145,11 +138,13 @@ class VRPN_API vrpn_Tracker_AnalogFly : public vrpn_Tracker {
 
     int setup_channel (vrpn_TAF_fullaxis * full);
     int teardown_channel (vrpn_TAF_fullaxis * full);
+    virtual void reset(void);
 
     static void	VRPN_CALLBACK handle_analog_update (void * userdata,
                                       const vrpn_ANALOGCB info);
     static void VRPN_CALLBACK handle_reset_press (void * userdata, const vrpn_BUTTONCB info);
     static void VRPN_CALLBACK handle_clutch_press (void * userdata, const vrpn_BUTTONCB info);
+    static int VRPN_CALLBACK handle_newConnection(void *, vrpn_HANDLERPARAM);
 };
 
 #endif

--- a/vrpn_Tracker_IMU.C
+++ b/vrpn_Tracker_IMU.C
@@ -1,0 +1,256 @@
+/// @file vrpn_Tracker_IMU.C
+/// @author Russ Taylor <russ@reliasolve.com>
+/// @license Standard VRPN license.
+
+#include "vrpn_Tracker_IMU.h"
+#include <cmath>
+
+#undef VERBOSE
+
+vrpn_IMU_Magnetometer::vrpn_IMU_Magnetometer
+          (std::string name, vrpn_Connection *output_con,
+           vrpn_IMU_Axis_Params x, vrpn_IMU_Axis_Params y, vrpn_IMU_Axis_Params z,
+           float update_rate, bool report_changes) :
+	vrpn_Analog_Server(name.c_str(), output_con),
+	d_update_interval (update_rate ? (1/update_rate) : 1.0),
+	d_report_changes (report_changes)
+{
+  // We have 3 output channels.
+  num_channel = 3;
+
+	//--------------------------------------------------------------------
+	// Set the current timestamp to "now" and current direction to along X.
+	// This is done in case we never hear from the analog devices.
+  vrpn_gettimeofday(&d_prevtime, NULL);
+  vrpn_Analog::timestamp = d_prevtime;
+  d_ox = 1; d_oy = 0; d_oz = 0;
+  channel[0] = d_ox;
+  channel[1] = d_oy;
+  channel[2] = d_oz;
+
+  // Set empty axis values.
+	d_x.params = x; d_y.params = y; d_z.params = z;
+	d_x.ana = d_y.ana = d_z.ana = NULL;
+	d_x.value = d_y.value = d_z.value = 0.0;
+  d_x.time = d_prevtime; d_y.time = d_prevtime; d_z.time = d_prevtime;
+
+	//--------------------------------------------------------------------
+	// Open analog remotes for any channels that have non-empty names.
+	//   If the name starts with the "*" character, use our output
+  // connection rather than getting a new connection for it.
+	//   Set up callbacks to handle updates to the analog values.
+	setup_axis(&d_x);
+	setup_axis(&d_y);
+	setup_axis(&d_z);
+
+	//--------------------------------------------------------------------
+  // Set the minimum and maximum values past each other and past what
+  // we expect from any real device, so they will be inialized properly
+  // the first time we get a report.
+  d_minx = d_miny = d_minz = 1e100;
+  d_maxx = d_maxy = d_maxz = -1e100;
+}
+
+vrpn_IMU_Magnetometer::~vrpn_IMU_Magnetometer()
+{
+	// Tear down the analog update callbacks and remotes
+	teardown_axis(&d_x);
+	teardown_axis(&d_y);
+	teardown_axis(&d_z);
+}
+
+// This routine handles updates of the analog values. The value coming in is
+// adjusted per the parameters in the axis description, and then used to
+// update the value there. The value is used by the device code in
+// mainloop() to update its internal state; that work is not done here.
+
+void	VRPN_CALLBACK vrpn_IMU_Magnetometer::handle_analog_update
+                     (void *userdata, const vrpn_ANALOGCB info)
+{
+	vrpn_IMU_Axis	*axis = (vrpn_IMU_Axis *)userdata;
+	double value = info.channel[axis->params.channel];
+
+	// Scale the value
+  axis->value = value * axis->params.scale;
+
+  // Store the time we got the value.
+  axis->time = info.msg_time;
+}
+
+// This sets up the Analog Remote for one axis, setting up the callback
+// needed to adjust the value based on changes in the analog input.
+// Returns 0 on success and -1 on failure.
+
+int	vrpn_IMU_Magnetometer::setup_axis(vrpn_IMU_Axis *axis)
+{
+  // Set a default value of 0 and a time of now.
+  struct timeval now;
+  vrpn_gettimeofday(&now, NULL);
+  axis->value = 0;
+  axis->time = now;
+
+	// If the name is empty, we're done.
+	if (axis->params.name.size() == 0) { return 0; }
+
+	// Open the analog device and point the remote at it.
+	// If the name starts with the '*' character, use the server
+  // connection rather than making a new one.
+	if (axis->params.name[0] == '*') {
+		axis->ana = new vrpn_Analog_Remote(axis->params.name.c_str()+1,
+                      d_connection);
+#ifdef	VERBOSE
+		printf("vrpn_Tracker_AnalogFly: Adding local analog %s\n",
+                          axis->params.name.c_str()+1);
+#endif
+	} else {
+		axis->ana = new vrpn_Analog_Remote(axis->params.name.c_str());
+#ifdef	VERBOSE
+		printf("vrpn_Tracker_AnalogFly: Adding remote analog %s\n",
+                          axis->params.name.c_str());
+#endif
+	}
+	if (axis->ana == NULL) {
+		fprintf(stderr,"vrpn_Tracker_AnalogFly: "
+                        "Can't open Analog %s\n",axis->params.name.c_str());
+		return -1;
+	}
+
+	// Set up the callback handler for the channel
+	return axis->ana->register_change_handler(axis, handle_analog_update);
+}
+
+// This tears down the Analog Remote for one channel, undoing everything that
+// the setup did. Returns 0 on success and -1 on failure.
+
+int	vrpn_IMU_Magnetometer::teardown_axis(vrpn_IMU_Axis *axis)
+{
+	int	ret;
+
+	// If the analog pointer is empty, we're done.
+	if (axis->ana == NULL) { return 0; }
+
+	// Turn off the callback handler for the channel
+	ret = axis->ana->unregister_change_handler((void*)axis,
+                          handle_analog_update);
+
+	// Delete the analog device.
+	delete axis->ana;
+
+	return ret;
+}
+ 
+void vrpn_IMU_Magnetometer::mainloop()
+{
+  struct timeval	now;
+  double	interval;	// How long since the last report, in secs
+
+  // Call generic server mainloop, since we are a server
+  server_mainloop();
+
+  // Keep track of the minimum and maximum values of
+  // our reports.
+  if (d_x.value < d_minx) { d_minx = d_x.value; }
+  if (d_y.value < d_miny) { d_miny = d_y.value; }
+  if (d_z.value < d_minz) { d_minz = d_z.value; }
+
+  if (d_x.value > d_maxx) { d_maxx = d_x.value; }
+  if (d_y.value > d_maxy) { d_maxy = d_y.value; }
+  if (d_z.value > d_maxz) { d_maxz = d_z.value; }
+
+  // Mainloop() all of the analogs that are defined
+  // so that we will get all of the values fresh.
+  if (d_x.ana != NULL) { d_x.ana->mainloop(); };
+  if (d_y.ana != NULL) { d_y.ana->mainloop(); };
+  if (d_z.ana != NULL) { d_z.ana->mainloop(); };
+
+  // See if it has been long enough since our last report.
+  // If so, generate a new one.
+  vrpn_gettimeofday(&now, NULL);
+  interval = vrpn_TimevalDurationSeconds(now, d_prevtime);
+
+  if (should_report(interval)) {
+
+    // Set the time on the report to the largest time of any
+    // of our axes.
+    struct timeval max_time = d_x.time;
+    if (vrpn_TimevalGreater(d_y.time, max_time)) {
+      max_time = d_y.time;
+    }
+    if (vrpn_TimevalGreater(d_z.time, max_time)) {
+      max_time = d_z.time;
+    }
+
+    // Compute the unit vector by finding the normalized
+    // distance between the min and max for each axis and
+    // converting it to the range (-1,1) and then normalizing
+    // the resulting vector.  Watch out for min and max
+    // being the same.
+    double dx = d_x.value - d_minx;
+    if (dx == 0) {
+      d_ox = 0;
+    } else {
+      d_ox = -1 + 2 * dx / (d_maxx - d_minx);
+    }
+    double dy = d_y.value - d_miny;
+    if (dy == 0) {
+      d_oy = 0;
+    } else {
+      d_oy = -1 + 2 * dy / (d_maxy - d_miny);
+    }
+    double dz = d_z.value - d_minz;
+    if (dz == 0) {
+      d_oz = 0;
+    } else {
+      d_oz = -1 + 2 * dz / (d_maxz - d_minz);
+    }
+    double len = sqrt( d_ox*d_ox + d_oy*d_oy + d_oz*d_oz );
+    if (len == 0) {
+      d_ox = 1;
+      d_oy = 0;
+      d_oz = 0;
+    } else {
+      d_ox /= len;
+      d_oy /= len;
+      d_oz /= len;
+    }
+
+    // pack and deliver analog unit vector report;
+    if (d_connection) {
+      channel[0] = d_ox;
+      channel[1] = d_oy;
+      channel[2] = d_oz;
+      vrpn_Analog_Server::report();
+    } else {
+      fprintf(stderr,"vrpn_IMU_Magnetometer: "
+              "No valid connection\n");
+    }
+
+    // We just sent a report, so reset the time
+    d_prevtime = now;
+  }
+
+  // We're not always sending reports, but we still want to
+  // update the interval clock so that we don't integrate over
+  // too long a timespan when we do finally report a change.
+  if (interval >= d_update_interval) {
+    d_prevtime = now;
+  }
+}
+
+bool vrpn_IMU_Magnetometer::should_report(double elapsedInterval) const
+{
+  // If we haven't had enough time pass yet, don't report.
+  if (elapsedInterval < d_update_interval) {
+    return VRPN_FALSE;
+  }
+
+  // If we're sending a report every interval, regardless of
+  // whether or not there are changes, then send one now.
+  if (!d_report_changes) {
+    return VRPN_TRUE;
+  }
+
+  // Enough time has elapsed, but nothing has changed, so return false.
+  return VRPN_FALSE;
+}
+

--- a/vrpn_Tracker_IMU.C
+++ b/vrpn_Tracker_IMU.C
@@ -9,7 +9,7 @@
 
 vrpn_IMU_Magnetometer::vrpn_IMU_Magnetometer
           (std::string name, vrpn_Connection *output_con,
-           vrpn_IMU_Axis_Params x, vrpn_IMU_Axis_Params y, vrpn_IMU_Axis_Params z,
+            vrpn_IMU_Axis_Params params,
            float update_rate, bool report_changes) :
 	vrpn_Analog_Server(name.c_str(), output_con),
 	d_update_interval (update_rate ? (1/update_rate) : 1.0),
@@ -23,40 +23,35 @@ vrpn_IMU_Magnetometer::vrpn_IMU_Magnetometer
 	// This is done in case we never hear from the analog devices.
   vrpn_gettimeofday(&d_prevtime, NULL);
   vrpn_Analog::timestamp = d_prevtime;
-  d_ox = 1; d_oy = 0; d_oz = 0;
-  channel[0] = d_ox;
-  channel[1] = d_oy;
-  channel[2] = d_oz;
+  channel[0] = 1;
+  channel[1] = 0;
+  channel[2] = 0;
 
   // Set empty axis values.
-	d_x.params = x; d_y.params = y; d_z.params = z;
-	d_x.ana = d_y.ana = d_z.ana = NULL;
-	d_x.value = d_y.value = d_z.value = 0.0;
-  d_x.time = d_prevtime; d_y.time = d_prevtime; d_z.time = d_prevtime;
+	d_vector.params = params;
+  d_vector.time = d_prevtime;
 
 	//--------------------------------------------------------------------
-	// Open analog remotes for any channels that have non-empty names.
+	// Open analog remote to use to listen to.
 	//   If the name starts with the "*" character, use our output
   // connection rather than getting a new connection for it.
-	//   Set up callbacks to handle updates to the analog values.
-	setup_axis(&d_x);
-	setup_axis(&d_y);
-	setup_axis(&d_z);
+	//   Set up callbacks to handle updates to the analog reports.
+	setup_vector(&d_vector);
 
 	//--------------------------------------------------------------------
   // Set the minimum and maximum values past each other and past what
   // we expect from any real device, so they will be inialized properly
   // the first time we get a report.
-  d_minx = d_miny = d_minz = 1e100;
-  d_maxx = d_maxy = d_maxz = -1e100;
+  for (size_t i = 0; i < 3; i++) {
+    d_mins[i] = 1e100;
+    d_maxes[i] = -1e100;
+  }
 }
 
 vrpn_IMU_Magnetometer::~vrpn_IMU_Magnetometer()
 {
 	// Tear down the analog update callbacks and remotes
-	teardown_axis(&d_x);
-	teardown_axis(&d_y);
-	teardown_axis(&d_z);
+	teardown_vector(&d_vector);
 }
 
 // This routine handles updates of the analog values. The value coming in is
@@ -67,74 +62,74 @@ vrpn_IMU_Magnetometer::~vrpn_IMU_Magnetometer()
 void	VRPN_CALLBACK vrpn_IMU_Magnetometer::handle_analog_update
                      (void *userdata, const vrpn_ANALOGCB info)
 {
-	vrpn_IMU_Axis	*axis = (vrpn_IMU_Axis *)userdata;
-	double value = info.channel[axis->params.channel];
-
-	// Scale the value
-  axis->value = value * axis->params.scale;
+  vrpn_IMU_Vector	*vector = (vrpn_IMU_Vector *)userdata;
+  for (size_t i = 0; i < 3; i++) {
+    vector->values[i] =
+      (info.channel[vector->params.channels[i]] - vector->params.offsets[i])
+      * vector->params.scales[i];
+  }
 
   // Store the time we got the value.
-  axis->time = info.msg_time;
+  vector->time = info.msg_time;
 }
 
-// This sets up the Analog Remote for one axis, setting up the callback
+// This sets up the Analog Remote for our vector, setting up the callback
 // needed to adjust the value based on changes in the analog input.
 // Returns 0 on success and -1 on failure.
 
-int	vrpn_IMU_Magnetometer::setup_axis(vrpn_IMU_Axis *axis)
+int	vrpn_IMU_Magnetometer::setup_vector(vrpn_IMU_Vector *vector)
 {
-  // Set a default value of 0 and a time of now.
+  // Set a default time of now.
   struct timeval now;
   vrpn_gettimeofday(&now, NULL);
-  axis->value = 0;
-  axis->time = now;
+  vector->time = now;
 
 	// If the name is empty, we're done.
-	if (axis->params.name.size() == 0) { return 0; }
+	if (vector->params.name.size() == 0) { return 0; }
 
 	// Open the analog device and point the remote at it.
 	// If the name starts with the '*' character, use the server
   // connection rather than making a new one.
-	if (axis->params.name[0] == '*') {
-		axis->ana = new vrpn_Analog_Remote(axis->params.name.c_str()+1,
+	if (vector->params.name[0] == '*') {
+		vector->ana = new vrpn_Analog_Remote(vector->params.name.c_str()+1,
                       d_connection);
 #ifdef	VERBOSE
-		printf("vrpn_Tracker_AnalogFly: Adding local analog %s\n",
-                          axis->params.name.c_str()+1);
+		printf("vrpn_IMU_Magnetometer: Adding local analog %s\n",
+      vector->params.name.c_str()+1);
 #endif
 	} else {
-		axis->ana = new vrpn_Analog_Remote(axis->params.name.c_str());
+    vector->ana = new vrpn_Analog_Remote(vector->params.name.c_str());
 #ifdef	VERBOSE
-		printf("vrpn_Tracker_AnalogFly: Adding remote analog %s\n",
-                          axis->params.name.c_str());
+		printf("vrpn_IMU_Magnetometer: Adding remote analog %s\n",
+      vector->params.name.c_str());
 #endif
 	}
-	if (axis->ana == NULL) {
-		fprintf(stderr,"vrpn_Tracker_AnalogFly: "
-                        "Can't open Analog %s\n",axis->params.name.c_str());
+	if (vector->ana == NULL) {
+		fprintf(stderr,"vrpn_IMU_Magnetometer: "
+      "Can't open Analog %s\n", vector->params.name.c_str());
 		return -1;
 	}
 
 	// Set up the callback handler for the channel
-	return axis->ana->register_change_handler(axis, handle_analog_update);
+	return vector->ana->register_change_handler(vector, handle_analog_update);
 }
 
-// This tears down the Analog Remote for one channel, undoing everything that
+// This tears down the Analog Remote for our vector, undoing everything that
 // the setup did. Returns 0 on success and -1 on failure.
 
-int	vrpn_IMU_Magnetometer::teardown_axis(vrpn_IMU_Axis *axis)
+int	vrpn_IMU_Magnetometer::teardown_vector(vrpn_IMU_Vector *vector)
 {
 	int	ret;
 
 	// If the analog pointer is empty, we're done.
-	if (axis->ana == NULL) { return 0; }
+	if (vector->ana == NULL) { return 0; }
 
 	// Turn off the callback handler for the channel
-	ret = axis->ana->unregister_change_handler((void*)axis,
+	ret = vector->ana->unregister_change_handler((void*)vector,
                           handle_analog_update);
 
 	// Delete the analog device.
-	delete axis->ana;
+	delete vector->ana;
 
 	return ret;
 }
@@ -147,79 +142,64 @@ void vrpn_IMU_Magnetometer::mainloop()
   // Call generic server mainloop, since we are a server
   server_mainloop();
 
-  // Keep track of the minimum and maximum values of
-  // our reports.
-  if (d_x.value < d_minx) { d_minx = d_x.value; }
-  if (d_y.value < d_miny) { d_miny = d_y.value; }
-  if (d_z.value < d_minz) { d_minz = d_z.value; }
-
-  if (d_x.value > d_maxx) { d_maxx = d_x.value; }
-  if (d_y.value > d_maxy) { d_maxy = d_y.value; }
-  if (d_z.value > d_maxz) { d_maxz = d_z.value; }
-
   // Mainloop() all of the analogs that are defined
   // so that we will get all of the values fresh.
-  if (d_x.ana != NULL) { d_x.ana->mainloop(); };
-  if (d_y.ana != NULL) { d_y.ana->mainloop(); };
-  if (d_z.ana != NULL) { d_z.ana->mainloop(); };
+  if (d_vector.ana != NULL) { d_vector.ana->mainloop(); };
+
+  // Keep track of the minimum and maximum values of
+  // our reports.
+  for (size_t i = 0; i < 3; i++) {
+    if (d_vector.values[i] < d_mins[i]) {
+      d_mins[i] = d_vector.values[i];
+    }
+    if (d_vector.values[i] > d_maxes[i]) {
+      d_maxes[i] = d_vector.values[i];
+    }
+  }
 
   // See if it has been long enough since our last report.
   // If so, generate a new one.
   vrpn_gettimeofday(&now, NULL);
   interval = vrpn_TimevalDurationSeconds(now, d_prevtime);
 
-  if (should_report(interval)) {
+  if (interval >= d_update_interval) {
 
-    // Set the time on the report to the largest time of any
-    // of our axes.
-    struct timeval max_time = d_x.time;
-    if (vrpn_TimevalGreater(d_y.time, max_time)) {
-      max_time = d_y.time;
-    }
-    if (vrpn_TimevalGreater(d_z.time, max_time)) {
-      max_time = d_z.time;
-    }
+    // Set the time on the report
+    timestamp = d_vector.time;
 
     // Compute the unit vector by finding the normalized
     // distance between the min and max for each axis and
     // converting it to the range (-1,1) and then normalizing
     // the resulting vector.  Watch out for min and max
     // being the same.
-    double dx = d_x.value - d_minx;
-    if (dx == 0) {
-      d_ox = 0;
-    } else {
-      d_ox = -1 + 2 * dx / (d_maxx - d_minx);
+    for (size_t i = 0; i < 3; i++) {
+      double diff = d_vector.values[i] - d_mins[i];
+      if (diff == 0) {
+        channel[i] = 0;
+      }
+      else {
+        channel[i] = -1 + 2 * diff / (d_maxes[i] - d_mins[i]);
+      }
     }
-    double dy = d_y.value - d_miny;
-    if (dy == 0) {
-      d_oy = 0;
-    } else {
-      d_oy = -1 + 2 * dy / (d_maxy - d_miny);
-    }
-    double dz = d_z.value - d_minz;
-    if (dz == 0) {
-      d_oz = 0;
-    } else {
-      d_oz = -1 + 2 * dz / (d_maxz - d_minz);
-    }
-    double len = sqrt( d_ox*d_ox + d_oy*d_oy + d_oz*d_oz );
+    double len = sqrt( channel[0] * channel[0] +
+      channel[1] * channel[1] + channel[2] * channel[2]);
     if (len == 0) {
-      d_ox = 1;
-      d_oy = 0;
-      d_oz = 0;
+      channel[0] = 1;
+      channel[1] = 0;
+      channel[2] = 0;
     } else {
-      d_ox /= len;
-      d_oy /= len;
-      d_oz /= len;
+      channel[0] /= len;
+      channel[1] /= len;
+      channel[2] /= len;
     }
 
     // pack and deliver analog unit vector report;
     if (d_connection) {
-      channel[0] = d_ox;
-      channel[1] = d_oy;
-      channel[2] = d_oz;
-      vrpn_Analog_Server::report();
+      if (d_report_changes) {
+        vrpn_Analog_Server::report_changes();
+      } else {
+        vrpn_Analog_Server::report();
+      }
     } else {
       fprintf(stderr,"vrpn_IMU_Magnetometer: "
               "No valid connection\n");
@@ -236,21 +216,3 @@ void vrpn_IMU_Magnetometer::mainloop()
     d_prevtime = now;
   }
 }
-
-bool vrpn_IMU_Magnetometer::should_report(double elapsedInterval) const
-{
-  // If we haven't had enough time pass yet, don't report.
-  if (elapsedInterval < d_update_interval) {
-    return VRPN_FALSE;
-  }
-
-  // If we're sending a report every interval, regardless of
-  // whether or not there are changes, then send one now.
-  if (!d_report_changes) {
-    return VRPN_TRUE;
-  }
-
-  // Enough time has elapsed, but nothing has changed, so return false.
-  return VRPN_FALSE;
-}
-

--- a/vrpn_Tracker_IMU.C
+++ b/vrpn_Tracker_IMU.C
@@ -452,6 +452,11 @@ void	vrpn_IMU_SimpleCombiner::update_matrix_based_on_values(double time_interval
   // error estimates from a Kalman or other filter.
   double scale = 1.0 - diff;
   if (scale > 0) {
+    // Get a new forward and inverse matrix from the current, just-
+    // rotated matrix.
+    q_copy(forward, d_quat);
+    q_invert(inverse, forward);
+
     // Change how fast we adjust based on how close we are to the
     // expected value of gravity.
     double gravity_rate = scale * d_gravity_restore_rate;
@@ -461,8 +466,10 @@ void	vrpn_IMU_SimpleCombiner::update_matrix_based_on_values(double time_interval
     q_vec_type gravity_local;
     q_vec_set(gravity_local, d_acceleration.values[0],
       d_acceleration.values[1], d_acceleration.values[2]);
+    //printf("XXX Local gravity: %lg, %lg, %lg\n", gravity_local[0], gravity_local[1], gravity_local[2]);
     q_vec_type gravity_global;
-    q_mult(gravity_global, inverse, gravity_local);
+    q_xform(gravity_global, inverse, gravity_local);
+    //printf("  XXX Global gravity: %lg, %lg, %lg\n", gravity_global[0], gravity_global[1], gravity_global[2]);
 
     // Determine the rotation needed to take negative Y and rotate
     // it into the direction of gravity.
@@ -498,6 +505,11 @@ void	vrpn_IMU_SimpleCombiner::update_matrix_based_on_values(double time_interval
     // around too quickly by only slowly re-adjust.
 
     if (d_magnetometer.ana != NULL) {
+      // Get a new forward and inverse matrix from the current, just-
+      // rotated matrix.
+      q_copy(forward, d_quat);
+      q_invert(inverse, forward);
+
       // Find the North vector that is perpendicular to gravity by
       // taking the cross product of north and down (which is west).
       // Then take the cross product of down and west, which is
@@ -513,7 +525,7 @@ void	vrpn_IMU_SimpleCombiner::update_matrix_based_on_values(double time_interval
       // Rotate the north vector from the local space into the
       // canonical orientation.
       q_vec_type north_global;
-      q_mult(north_global, inverse, north_local);
+      q_xform(north_global, inverse, north_local);
 
       // Determine the rotation needed to take negative Z and rotate
       // it into the direction of north.

--- a/vrpn_Tracker_IMU.C
+++ b/vrpn_Tracker_IMU.C
@@ -1,5 +1,6 @@
 /// @file vrpn_Tracker_IMU.C
-/// @author Russ Taylor <russ@reliasolve.com>
+/// @copyright 2015 ReliaSolve.com
+/// @author ReliaSolve.com russ@reliasolve.com
 /// @license Standard VRPN license.
 
 #include "vrpn_Tracker_IMU.h"

--- a/vrpn_Tracker_IMU.C
+++ b/vrpn_Tracker_IMU.C
@@ -217,7 +217,7 @@ void vrpn_IMU_Magnetometer::mainloop()
   }
 }
 
-vrpn_UMI_SimpleCombiner::vrpn_UMI_SimpleCombiner
+vrpn_IMU_SimpleCombiner::vrpn_IMU_SimpleCombiner
     (const char * name, vrpn_Connection * trackercon,
       vrpn_Tracker_IMU_Params *params,
       float update_rate, bool report_changes)
@@ -262,7 +262,7 @@ vrpn_UMI_SimpleCombiner::vrpn_UMI_SimpleCombiner
   vel_quat_dt = 1;
 }
 
-vrpn_UMI_SimpleCombiner::~vrpn_UMI_SimpleCombiner(void)
+vrpn_IMU_SimpleCombiner::~vrpn_IMU_SimpleCombiner(void)
 {
   // Tear down the analog update callbacks and remotes
   teardown_vector(&d_acceleration, handle_analog_update);
@@ -275,7 +275,7 @@ vrpn_UMI_SimpleCombiner::~vrpn_UMI_SimpleCombiner(void)
 // update the value there. The value is used by the device code in
 // mainloop() to update its internal state; that work is not done here.
 
-void	VRPN_CALLBACK vrpn_UMI_SimpleCombiner::handle_analog_update
+void	VRPN_CALLBACK vrpn_IMU_SimpleCombiner::handle_analog_update
 (void *userdata, const vrpn_ANALOGCB info)
 {
   vrpn_IMU_Vector	*vector = (vrpn_IMU_Vector *)userdata;
@@ -293,7 +293,7 @@ void	VRPN_CALLBACK vrpn_UMI_SimpleCombiner::handle_analog_update
 // needed to adjust the value based on changes in the analog input.
 // Returns 0 on success and -1 on failure.
 
-int	vrpn_UMI_SimpleCombiner::setup_vector(vrpn_IMU_Vector *vector,
+int	vrpn_IMU_SimpleCombiner::setup_vector(vrpn_IMU_Vector *vector,
   vrpn_ANALOGCHANGEHANDLER f)
 {
   // If the name is empty, we're done.
@@ -330,7 +330,7 @@ int	vrpn_UMI_SimpleCombiner::setup_vector(vrpn_IMU_Vector *vector,
 // This tears down the Analog Remote for one channel, undoing everything that
 // the setup did. Returns 0 on success and -1 on failure.
 
-int	vrpn_UMI_SimpleCombiner::teardown_vector(vrpn_IMU_Vector *vector,
+int	vrpn_IMU_SimpleCombiner::teardown_vector(vrpn_IMU_Vector *vector,
   vrpn_ANALOGCHANGEHANDLER f)
 {
   int	ret;
@@ -347,9 +347,8 @@ int	vrpn_UMI_SimpleCombiner::teardown_vector(vrpn_IMU_Vector *vector,
   return ret;
 }
 
-void vrpn_UMI_SimpleCombiner::mainloop()
+void vrpn_IMU_SimpleCombiner::mainloop()
 {
-
   // Call generic server mainloop, since we are a server
   server_mainloop();
 
@@ -379,18 +378,18 @@ void vrpn_UMI_SimpleCombiner::mainloop()
       if (d_connection->pack_message(len, vrpn_Tracker::timestamp,
         position_m_id, d_sender_id, msgbuf,
         vrpn_CONNECTION_LOW_LATENCY)) {
-        fprintf(stderr, "vrpn_UMI_SimpleCombiner: "
+        fprintf(stderr, "vrpn_IMU_SimpleCombiner: "
           "cannot write pose message: tossing\n");
       }
       len = encode_vel_to(msgbuf);
       if (d_connection->pack_message(len, vrpn_Tracker::timestamp,
         velocity_m_id, d_sender_id, msgbuf,
         vrpn_CONNECTION_LOW_LATENCY)) {
-        fprintf(stderr, "vrpn_UMI_SimpleCombiner: "
+        fprintf(stderr, "vrpn_IMU_SimpleCombiner: "
           "cannot write velocity message: tossing\n");
       }
     } else {
-      fprintf(stderr, "vrpn_UMI_SimpleCombiner: "
+      fprintf(stderr, "vrpn_IMU_SimpleCombiner: "
         "No valid connection\n");
     }
 
@@ -403,7 +402,7 @@ void vrpn_UMI_SimpleCombiner::mainloop()
 // in the offsets list for each axis, and the length of time over which the
 // action is taking place (time_interval).
 
-void	vrpn_UMI_SimpleCombiner::update_matrix_based_on_values(double time_interval)
+void	vrpn_IMU_SimpleCombiner::update_matrix_based_on_values(double time_interval)
 {
   //==================================================================
   // Adjust the orientation based on the rotational velocity, which is

--- a/vrpn_Tracker_IMU.C
+++ b/vrpn_Tracker_IMU.C
@@ -227,8 +227,8 @@ vrpn_IMU_SimpleCombiner::vrpn_IMU_SimpleCombiner
   d_report_changes(report_changes)
 {
   // Set the restoration rates for gravity and north.
-  d_gravity_restore_rate = 0.5;
-  d_north_restore_rate = 0.5;
+  d_gravity_restore_rate = 0;
+  d_north_restore_rate = 0;
 
   // Hook up the parameters for acceleration and rotational velocity
   d_acceleration.params = params->d_acceleration;
@@ -551,7 +551,6 @@ void	vrpn_IMU_SimpleCombiner::update_matrix_based_on_values(double time_interval
   // rotated in a hundredth of a second and set the rotational
   // velocity dt to a hundredth of a second so that we don't
   // risk wrapping.
-  q_invert(inverse, d_quat);
   // Remember that Euler angles in Quatlib have rotation around Z in
   // the first term.  Compute the time-scaled delta transform in
   // canonical space.
@@ -560,7 +559,8 @@ void	vrpn_IMU_SimpleCombiner::update_matrix_based_on_values(double time_interval
     1e-2 * d_rotational_vel.values[Q_Y],
     1e-2 * d_rotational_vel.values[Q_X]);
   // Bring the delta back into canonical space
-  q_mult(vel_quat, inverse, delta);
+  q_mult(canonical, delta, inverse);
+  q_mult(vel_quat, forward, canonical);
   vel_quat_dt = 1e-2;
 }
 

--- a/vrpn_Tracker_IMU.h
+++ b/vrpn_Tracker_IMU.h
@@ -1,0 +1,225 @@
+/// @file vrpn_Tracker_IMU.h
+/// @author Russ Taylor <russ@reliasolve.com>
+/// @license Standard VRPN license.
+
+/// This file contains classes useful in producing tracker reports
+/// from inertial-navitation units (IMUs).  Initially, it implements
+/// the classes needed to take inputs from a magnetometer (compass),
+/// accelerometer (gravity++) and a rate gyroscope output from
+/// vrpn_Analog devices and merge them into an estimate of orientation.
+
+#pragma once
+
+#include <quat.h>                       // for q_matrix_type
+#include <stdio.h>                      // for NULL
+#include <string>
+#include "vrpn_Analog.h"                // for vrpn_ANALOGCB, etc
+#include "vrpn_Tracker.h"               // for vrpn_Tracker
+
+/// @brief Describes information passed to the constructor for the
+/// various IMUs.
+/// It describes the analog channel to use to drive the axis
+/// as well as the scale (and polarity) of the mapping to that axis.
+
+class vrpn_IMU_Axis_Params {
+
+public:
+
+  VRPN_API vrpn_IMU_Axis_Params(void) { channel = 0; scale = 1; }
+
+  std::string name;	//< Name of the Analog device driving this axis
+  int channel;	    //< Which channel to use from the Analog device
+  double scale;     //< Scale, and positive or negative axis
+};
+
+class VRPN_API vrpn_IMU_Axis {
+public:
+  vrpn_IMU_Axis (void) { ana = NULL; value = 0.0; 
+        time.tv_sec = 0; time.tv_usec = 0; };
+
+  vrpn_IMU_Axis_Params  params;
+  vrpn_Analog_Remote    *ana;
+  double                value;
+  struct timeval        time;
+};
+
+/// @brief Normalizes the three directions for a magnetometer into
+/// a unit vector.
+///
+/// This class acts as an analog-to-analog filter. It is given
+/// three axes to manage.  For each axis, it keeps track of the
+/// minimum and maximum value it has ever received and maps the
+/// current value into the range -1..1 based on that range.
+///   It then normalizes the resulting vector, producing a unit
+/// vector that should auto-calibrate itself over time to provide
+/// a unit direction vector (as a 3-output analog) pointing in
+/// the direction of magnetic north.
+
+class vrpn_IMU_Magnetometer : public vrpn_Analog_Server {
+  public:
+    /// @brief Constructor
+    /// @param name The name to give to the Analog_Server output device.
+    /// @param output_con The connection to report on.
+    /// @param x The parameters for the X axis.
+    /// @param y The parameters for the Y axis.
+    /// @param z The parameters for the Z axis.
+    /// @param update_rate How often to send reports.  If report_changes
+    ///        is true, it will only report at most this often.  If
+    ///        report_changes is false, it will send reports at this
+    ///        rate whether it has received new values or not.
+    /// @param report_changes If true, only reports values when at least
+    ///        one of them a changed.  If false, report values at the
+    ///        specified rate whether or not they have changed.
+    VRPN_API vrpn_IMU_Magnetometer(std::string name, vrpn_Connection *output_con,
+          vrpn_IMU_Axis_Params x, vrpn_IMU_Axis_Params y, vrpn_IMU_Axis_Params z,
+          float update_rate, bool report_changes = VRPN_FALSE);
+
+    virtual VRPN_API ~vrpn_IMU_Magnetometer();
+
+    /// Override base class function.
+    void mainloop();
+
+  protected:
+    double	    d_update_interval;	//< How long to wait between sends
+    struct timeval  d_prevtime;		  //< Time of the previous report
+    bool        d_report_changes;   //< Call report_changes() or report()?
+
+    /// Axes to handle gathering and scaling the required data.
+    vrpn_IMU_Axis	d_x, d_y, d_z;
+
+    /// Minimum, maximum, and current values for each axis.
+    double d_ox, d_minx, d_maxx;
+    double d_oy, d_miny, d_maxy;
+    double d_oz, d_minz, d_maxz;
+
+    int setup_axis(vrpn_IMU_Axis *axis);
+    int teardown_axis(vrpn_IMU_Axis *axis);
+
+    /// Should we send a new report now?
+    bool should_report (double elapsedInterval) const;
+
+    static void	VRPN_CALLBACK handle_analog_update (void * userdata,
+                                      const vrpn_ANALOGCB info);
+};
+
+#if 0
+
+class VRPN_API vrpn_Tracker_IMU_Params {
+
+  public:
+
+    vrpn_Tracker_AnalogFlyParam (void) {
+        x.name = y.name = z.name =
+        sx.name = sy.name = sz.name = reset_name = clutch_name = NULL;
+    }
+
+    /// Translation along each of these three axes
+    vrpn_TAF_axis x, y, z;
+
+    /// Rotation in the positive direction about the three axes
+    vrpn_TAF_axis sx, sy, sz;
+
+    /// Button device that is used to reset the matrix to the origin
+
+    char * reset_name;
+    int reset_which;
+
+    /// Clutch device that is used to enable relative motion over
+    // large distances
+
+    char * clutch_name;
+    int clutch_which;
+};
+
+class VRPN_API vrpn_Tracker_AnalogFly;	// Forward reference
+
+class VRPN_API vrpn_TAF_fullaxis {
+public:
+        vrpn_TAF_fullaxis (void) { ana = NULL; value = 0.0; af = NULL; };
+
+	vrpn_TAF_axis axis;
+        vrpn_Analog_Remote * ana;
+	vrpn_Tracker_AnalogFly * af;
+        double value;
+};
+
+/// This class will turn an analog device such as a joystick or a camera
+// tracker into a tracker by interpreting the joystick
+// positions as either position or velocity inputs and "flying" the user
+// around based on analog values.
+// The "absolute" parameter tells whether the tracker integrates differential
+// changes (the default, with FALSE) or takes the analog values as absolute
+// positions or orientations.
+// The mapping from analog channels to directions (or orientation changes) is
+// described in the vrpn_Tracker_AnalogFlyParam parameter. For translations,
+// values above threshold are multiplied by the scale and then taken to the
+// power; the result is the number of meters (or meters per second) to move
+// in that direction. For rotations, the result is taken as the number of
+// revolutions (or revolutions per second) around the given axis.
+// Note that the reset button has no effect on an absolute tracker.
+// The time reported by absolute trackers is as of the last report they have
+// had from their analog devices.  The time reported by differential trackers
+// is the local time that the report was generated.  This is to allow a
+// gen-locked camera tracker to have its time values passed forward through
+// the AnalogFly class.
+
+// If reportChanges is TRUE, updates are ONLY sent if there has been a
+// change since the last update, in which case they are generated no faster
+// than update_rate. 
+
+// If worldFrame is TRUE, then translations and rotations take place in the
+// world frame, rather than the local frame. Useful for a simulated wand
+// when doing desktop testing of immersive apps - easier to keep under control.
+
+class VRPN_API vrpn_Tracker_AnalogFly : public vrpn_Tracker {
+  public:
+    vrpn_Tracker_AnalogFly (const char * name, vrpn_Connection * trackercon,
+			    vrpn_Tracker_AnalogFlyParam * params,
+                            float update_rate, bool absolute = vrpn_FALSE,
+                            bool reportChanges = VRPN_FALSE, bool worldFrame = VRPN_FALSE);
+
+    virtual ~vrpn_Tracker_AnalogFly (void);
+
+    virtual void mainloop ();
+    virtual void reset (void);
+
+    void update (q_matrix_type &);
+
+    static void VRPN_CALLBACK handle_joystick (void *, const vrpn_ANALOGCB);
+    static int VRPN_CALLBACK handle_newConnection (void *, vrpn_HANDLERPARAM);
+
+  protected:
+
+    double	    d_update_interval;	//< How long to wait between sends
+    struct timeval  d_prevtime;		//< Time of the previous report
+    bool	    d_absolute;		//< Report absolute (vs. differential)?
+    bool       d_reportChanges;
+    bool       d_worldFrame;
+
+    vrpn_TAF_fullaxis	d_x, d_y, d_z, d_sx, d_sy, d_sz;
+    vrpn_Button_Remote	* d_reset_button;
+    int			d_which_button;
+
+    vrpn_Button_Remote	* d_clutch_button;
+    int			d_clutch_which;
+    bool                d_clutch_engaged;
+    bool		d_clutch_was_off;
+
+    q_matrix_type d_initMatrix, d_currentMatrix, d_clutchMatrix;
+
+    void    update_matrix_based_on_values (double time_interval);
+    void    convert_matrix_to_tracker (void);
+
+    bool shouldReport (double elapsedInterval) const;
+
+    int setup_channel (vrpn_TAF_fullaxis * full);
+    int teardown_channel (vrpn_TAF_fullaxis * full);
+
+    static void	VRPN_CALLBACK handle_analog_update (void * userdata,
+                                      const vrpn_ANALOGCB info);
+    static void VRPN_CALLBACK handle_reset_press (void * userdata, const vrpn_BUTTONCB info);
+    static void VRPN_CALLBACK handle_clutch_press (void * userdata, const vrpn_BUTTONCB info);
+};
+
+#endif
+

--- a/vrpn_Tracker_IMU.h
+++ b/vrpn_Tracker_IMU.h
@@ -1,5 +1,6 @@
 /// @file vrpn_Tracker_IMU.h
-/// @author Russ Taylor <russ@reliasolve.com>
+/// @copyright 2015 ReliaSolve.com
+/// @author ReliaSolve.com russ@reliasolve.com
 /// @license Standard VRPN license.
 
 /// This file contains classes useful in producing tracker reports

--- a/vrpn_Tracker_IMU.h
+++ b/vrpn_Tracker_IMU.h
@@ -117,8 +117,10 @@ public:
 // interpreting them as inertial-measurement report vectors.  The two required
 // inputs are an acceleration vector and a rotational velocity measurement.  There
 // is an optional magnetometer.
-// The time reported by is as of the last report received from any device.
-// If reportChanges is TRUE, updates are ONLY sent if there has been a
+//  NOTE: The coordinate system of the HMD has X to the right as the device
+// is worn, Y facing up, and Z pointing out the back of the wearer's head.
+//  The time reported by is as of the last report received from any device.
+//  If reportChanges is TRUE, updates are ONLY sent if there has been a
 // change since the last update, in which case they are generated no faster
 // than update_rate. 
 
@@ -133,14 +135,16 @@ class vrpn_IMU_SimpleCombiner : public vrpn_Tracker {
     virtual VRPN_API void mainloop ();
 
   protected:
-
     double	    d_update_interval;	//< How long to wait between sends
     struct timeval  d_prevtime;	  	//< Time of the previous report
     bool       d_report_changes;    //< Report only changes, or always?
 
-    vrpn_IMU_Vector d_acceleration;      //< Analog input for accelerometer
-    vrpn_IMU_Vector d_rotational_vel;    //< Analog input for rotational velocity
-    vrpn_IMU_Vector d_magnetometer;      //< Analog input for magnetometer, if present
+    vrpn_IMU_Vector d_acceleration;     //< Analog input for accelerometer
+    vrpn_IMU_Vector d_rotational_vel;   //< Analog input for rotational velocity
+    vrpn_IMU_Vector d_magnetometer;     //< Analog input for magnetometer, if present
+
+    double  d_gravity_restore_rate;     //< Radians/second to restore gravity vector
+    double  d_north_restore_rate;       //< Radians/second to restore North vector
 
     struct timeval d_prev_update_time;  //< Time of previous integration update
     void    update_matrix_based_on_values(double time_interval);
@@ -151,3 +155,4 @@ class vrpn_IMU_SimpleCombiner : public vrpn_Tracker {
     static void	VRPN_CALLBACK handle_analog_update(void *userdata,
       const vrpn_ANALOGCB info);
 };
+

--- a/vrpn_Tracker_IMU.h
+++ b/vrpn_Tracker_IMU.h
@@ -77,7 +77,7 @@ public:
   /// @param report_changes If true, only reports values when at least
   ///        one of them a changed.  If false, report values at the
   ///        specified rate whether or not they have changed.
-  VRPN_API vrpn_IMU_Magnetometer(std::string name, vrpn_Connection *output_con,
+  VRPN_API vrpn_IMU_Magnetometer(std::string const &name, vrpn_Connection *output_con,
         vrpn_IMU_Axis_Params params, float update_rate,
         bool report_changes = VRPN_FALSE);
 

--- a/vrpn_Tracker_IMU.h
+++ b/vrpn_Tracker_IMU.h
@@ -121,13 +121,13 @@ public:
 // change since the last update, in which case they are generated no faster
 // than update_rate. 
 
-class vrpn_UMI_SimpleCombiner : public vrpn_Tracker {
+class vrpn_IMU_SimpleCombiner : public vrpn_Tracker {
   public:
-    VRPN_API vrpn_UMI_SimpleCombiner(const char *name, vrpn_Connection *trackercon,
+    VRPN_API vrpn_IMU_SimpleCombiner(const char *name, vrpn_Connection *trackercon,
       vrpn_Tracker_IMU_Params *params,
       float update_rate, bool report_changes = VRPN_FALSE);
 
-    virtual VRPN_API ~vrpn_UMI_SimpleCombiner(void);
+    virtual VRPN_API ~vrpn_IMU_SimpleCombiner(void);
 
     virtual VRPN_API void mainloop ();
 

--- a/vrpndll.vcproj
+++ b/vrpndll.vcproj
@@ -2296,6 +2296,26 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="vrpn_Oculus.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="vrpn_Tracker_OSVRHackerDevKit.C"
 				>
 				<FileConfiguration
@@ -3130,6 +3150,10 @@
 			</File>
 			<File
 				RelativePath="vrpn_Tracker_NovintFalcon.h"
+				>
+			</File>
+			<File
+				RelativePath="vrpn_Oculus.h"
 				>
 			</File>
 			<File

--- a/vrpndll.vcproj
+++ b/vrpndll.vcproj
@@ -1956,6 +1956,17 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="vrpn_Tracker_IMU.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			<File
 				RelativePath="vrpn_Tracker_AnalogFly.C"
 				>
 				<FileConfiguration
@@ -3086,6 +3097,10 @@
 			</File>
 			<File
 				RelativePath="vrpn_Tracker_AnalogFly.h"
+				>
+			</File>
+			<File
+				RelativePath="vrpn_Tracker_IMU.h"
 				>
 			</File>
 			<File


### PR DESCRIPTION
Creates an analog-only driver for the Oculus DK2.  Handles both the case where the LEDs are asked to be on and where they are asked to be off.  Does not yet handle reading calibration data off the device.  Does not support video-based tracking even when the LEDs are on.

Tested on Windows 8.1, Visual Studio 2015.