### PR TITLE
Change how we turn the raw angular velocity from HDK into a quat.

### DIFF
--- a/vrpn_Tracker_OSVRHackerDevKit.C
+++ b/vrpn_Tracker_OSVRHackerDevKit.C
@@ -17,6 +17,7 @@
 
 #include <cstring>   // for memset
 #include <stdexcept> // for logic_error
+#include <cmath>
 
 VRPN_SUPPRESS_EMPTY_OBJECT_WARNING()
 


### PR DESCRIPTION
Instead of using the "quat from euler" function, this uses the fact that angular velocities as provided are in fact rotation vectors: the normalized vector provides the axis, and the length provides the angular speed about that axis.