### PR TITLE
Fix timezone

### DIFF
--- a/vrpn_Shared.C
+++ b/vrpn_Shared.C
@@ -22,7 +22,7 @@
 #define CHECK(a) \
     if (a == -1) return -1
 
-#if !defined(timezone)
+#if defined(VRPN_USE_WINSOCK_SOCKETS)
 /* from HP-UX */
 struct timezone {
 	int tz_minuteswest; /* minutes west of Greenwich */

--- a/vrpn_Shared.h
+++ b/vrpn_Shared.h
@@ -121,7 +121,7 @@
 // Whether or not we export gettimeofday, we declare the
 // vrpn_gettimeofday() function on Windows.
 extern "C" VRPN_API int vrpn_gettimeofday(struct timeval *tp,
-                                          struct timezone *tzp);
+                                          void *tzp = NULL);
 
 // If compiling under Cygnus Solutions Cygwin then these get defined by
 // including sys/time.h.  So, we will manually define only for _WIN32
@@ -129,17 +129,7 @@ extern "C" VRPN_API int vrpn_gettimeofday(struct timeval *tp,
 // so that application code can get at it.  All VRPN routines should be
 // calling vrpn_gettimeofday() directly.
 
-#if defined(VRPN_EXPORT_GETTIMEOFDAY) && !defined(_STRUCT_TIMEZONE) &&         \
-    !defined(_TIMEZONE_DEFINED)
-#define _TIMEZONE_DEFINED
-/* from HP-UX */
-struct timezone {
-    int tz_minuteswest; /* minutes west of Greenwich */
-    int tz_dsttime;     /* type of dst correction */
-};
-#endif
-#if defined(VRPN_EXPORT_GETTIMEOFDAY) && !defined(_STRUCT_TIMEZONE)
-#define _STRUCT_TIMEZONE
+#if defined(VRPN_EXPORT_GETTIMEOFDAY)
 
 // manually define this too.  _WIN32 sans cygwin doesn't have gettimeofday
 #define gettimeofday vrpn_gettimeofday


### PR DESCRIPTION
Pulled the definition of struct timezone back into the C file and made it an optional parameter in the vrpn_gettimeofday() function because many people won't be using it.  Guarded it so that it only shows up when using the Windows definitions so the code still compiles under Linux and mac.  Also under Cygwin.