### PR TITLE
Shield

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,6 +1082,7 @@ set(VRPN_SERVER_SOURCES
 	vrpn_NationalInstruments.C
 	vrpn_Nidaq.C
 	vrpn_nikon_controls.C
+  vrpn_nVidia_shield_controller.C
 	vrpn_Oculus.C
 	vrpn_OmegaTemperature.C
 	vrpn_Poser_Analog.C
@@ -1189,6 +1190,7 @@ set(VRPN_SERVER_PUBLIC_HEADERS
 	vrpn_NationalInstruments.h
 	vrpn_Nidaq.h
 	vrpn_nikon_controls.h
+  vrpn_nVidia_shield_controller.h
 	vrpn_Oculus.h
 	vrpn_OmegaTemperature.h
 	vrpn_OneEuroFilter.h

--- a/Makefile
+++ b/Makefile
@@ -692,6 +692,7 @@ SLIB_FILES =  $(LIB_FILES) \
 	vrpn_Microsoft_Controller_Raw.C \
 	vrpn_Mouse.C \
 	vrpn_NationalInstruments.C \
+	vrpn_nVidia_shield_controller.C \
 	vrpn_Oculus.C \
 	vrpn_OmegaTemperature.C \
 	vrpn_Poser_Analog.C \
@@ -784,6 +785,7 @@ SLIB_INCLUDES = $(LIB_INCLUDES) \
 	vrpn_Microsoft_Controller_Raw.h \
 	vrpn_Mouse.h \
 	vrpn_NationalInstruments.h \
+	vrpn_nVidia_shield_controller.h \
 	vrpn_Oculus.h \
 	vrpn_OmegaTemperature.h \
 	vrpn_OneEuroFilter.h \

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3189,3 +3189,45 @@
 #*Oculus0 2 0 -1.0 3 0 -1.0 4 0 -1.0
 #*Oculus0 5 0 1.0 6 0 1.0 7 0 1.0
 #*Magnetometer0
+
+################################################################################
+# nVidia Shield controllers.  The only argument is the name of the device to open.
+#
+# Analogs:
+#  analog[0] is the left joystick X, -1 to left and 1 to right.
+#  analog[1] is the left joystick Y, -1 up and 1 down.
+#  analog[2] is the right joystick X, -1 to left and 1 to right.
+#  analog[3] is the right joystick Y, -1 up and 1 down.
+#  analog[4] is the left finger bumper, 0 unpressed and 1 pressed fully.
+#  analog[5] is the right finger bumper, 0 unpressed and 1 pressed fully.
+#  analog[6] is the touch pad X axis, lower to left and higher to right
+#  analog[7] is the touch pad Y axis, lower to top and higher to bottom
+#  analog[8] is the hi-hat X position (-1 left, 0 center, 1 right)
+#  analog[9] is the hi-hat Y position (-1 up, 0 center, 1 down)
+#
+# Buttons:
+#  button[0] A
+#  button[1] B
+#  button[2] X
+#  button[3] Y
+#  button[4] Left finger trigger
+#  button[5] Right finger trigger
+#  button[6] Left joystick pushed down
+#  button[7] Right joystick pushed down
+#  button[8] Touch pad assembly (including volume control) pressed down
+#  button[9] Play/pause icon touched
+#  button[10] Unknown
+#  button[11] Right volume control (+) pressed
+#  button[12] Left volume control (-) pressed
+#  button[13] Shield emblem touched
+#  button[14] Back icon touched
+#  button[15] Home icon touched
+#  button[16] Hi-hat up pressed (may chord with left/right)
+#  button[17] Hi-hat right pressed (may chord with up/down)
+#  button[18] Hi-hat down pressed (may chord with left/right)
+#  button[19] Hi-hat left pressed (may chord with up/down)
+#  button[20] Touch pad touched
+#
+
+#vrpn_nVidia_shield_USB shield0
+

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3193,6 +3193,15 @@
 ################################################################################
 # nVidia Shield controllers.  The only argument is the name of the device to open.
 #
+# Note: On a mac, this controller sometimes requests shutdown on the machine
+#       when it is plugged in, and the volume controls control the volume,
+#       and the shield emblem causes it to sleep.  The events are still
+#       passed through to VRPN.
+# Note: On Windows 8.1, this controller's touch pad controls the mouse and
+#       its analog events are not passed on to VRPN.
+# On Linux, there are no system controls and all of the events are passed through
+# to VRPN.
+#
 # Analogs:
 #  analog[0] is the left joystick X, -1 to left and 1 to right.
 #  analog[1] is the left joystick Y, -1 up and 1 down.

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -55,6 +55,7 @@
 #include "vrpn_Mouse.h"                    // for vrpn_Button_SerialMouse, etc
 #include "vrpn_NationalInstruments.h"
 #include "vrpn_nikon_controls.h"   // for vrpn_Nikon_Controls
+#include "vrpn_nVidia_shield_controller.h"
 #include "vrpn_Oculus.h"           // for vrpn_Oculus_DK2
 #include "vrpn_OmegaTemperature.h" // for vrpn_OmegaTemperature
 #include "vrpn_Phantom.h"
@@ -5022,6 +5023,31 @@ int vrpn_Generic_Server_Object::setup_IMU_SimpleCombiner(char *&pch, char *line,
   return 0;
 }
 
+int vrpn_Generic_Server_Object::setup_nVidia_shield_USB(char *&pch, char *line, FILE *)
+{
+  char s2[LINESIZE];
+
+  VRPN_CONFIG_NEXT();
+  int ret = sscanf(pch, "%511s", s2);
+  if (ret != 1) {
+    fprintf(stderr, "Bad nVidia_shield_USB line: %s\n", line);
+    return -1;
+  }
+
+  // Open the shield
+  if (verbose) {
+    printf("Opening vrpn_nVidia_shield_USB\n");
+  }
+
+#ifdef VRPN_USE_HID
+  _devices->add(new vrpn_nVidia_shield_USB(s2, connection));
+#else
+  fprintf(stderr,
+    "nVidia_shield_USB driver works only with VRPN_USE_HID defined!\n");
+#endif
+  return 0; // successful completion
+}
+
 #undef VRPN_CONFIG_NEXT
 
 vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
@@ -5586,6 +5612,9 @@ vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
                 }
                 else if (VRPN_ISIT("vrpn_IMU_SimpleCombiner")) {
                   VRPN_CHECK(setup_IMU_SimpleCombiner);
+                }
+                else if (VRPN_ISIT("vrpn_nVidia_shield_USB")) {
+                  VRPN_CHECK(setup_nVidia_shield_USB);
                 }
                 else {                         // Never heard of it
                     sscanf(line, "%511s", s1); // Find out the class name

--- a/server_src/vrpn_Generic_server_object.h
+++ b/server_src/vrpn_Generic_server_object.h
@@ -164,6 +164,7 @@ protected:
     int setup_Oculus_DK2_inertial(char *&pch, char *line, FILE *config_file);
     int setup_IMU_Magnetometer(char *&pch, char *line, FILE *config_file);
     int setup_IMU_SimpleCombiner(char *&pch, char *line, FILE *config_file);
+    int setup_nVidia_shield_USB(char *&pch, char *line, FILE *config_file);
 
     template <typename T>
     int templated_setup_device_name_only(char *&pch, char *line, FILE *);

--- a/vrpn.vcproj
+++ b/vrpn.vcproj
@@ -1493,6 +1493,46 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="vrpn_nVidia_shield_controller.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="vrpn_Oculus.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="vrpn_OmegaTemperature.C"
 				>
 				<FileConfiguration
@@ -1933,26 +1973,6 @@
 				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="vrpn_Tracker_IMU.C"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						CompileAs="2"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						CompileAs="2"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
 				RelativePath="vrpn_Tracker_ButtonFly.C"
 				>
 				<FileConfiguration
@@ -2113,6 +2133,26 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="vrpn_Tracker_IMU.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="vrpn_Tracker_isense.C"
 				>
 				<FileConfiguration
@@ -2254,26 +2294,6 @@
 			</File>
 			<File
 				RelativePath="vrpn_Tracker_NovintFalcon.C"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						CompileAs="2"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						CompileAs="2"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="vrpn_Oculus.C"
 				>
 				<FileConfiguration
 					Name="Release|Win32"
@@ -2970,6 +2990,14 @@
 				>
 			</File>
 			<File
+				RelativePath="vrpn_nVidia_shield_controller.h"
+				>
+			</File>
+			<File
+				RelativePath="vrpn_Oculus.h"
+				>
+			</File>
+			<File
 				RelativePath="vrpn_OmegaTemperature.h"
 				>
 			</File>
@@ -3066,10 +3094,6 @@
 				>
 			</File>
 			<File
-				RelativePath="vrpn_Tracker_IMU.h"
-				>
-			</File>
-			<File
 				RelativePath="vrpn_Tracker_ButtonFly.h"
 				>
 			</File>
@@ -3102,6 +3126,10 @@
 				>
 			</File>
 			<File
+				RelativePath="vrpn_Tracker_IMU.h"
+				>
+			</File>
+			<File
 				RelativePath="vrpn_Tracker_isense.h"
 				>
 			</File>
@@ -3131,10 +3159,6 @@
 			</File>
 			<File
 				RelativePath="vrpn_Tracker_NovintFalcon.h"
-				>
-			</File>
-			<File
-				RelativePath="vrpn_Oculus.h"
 				>
 			</File>
 			<File

--- a/vrpn_nVidia_shield_controller.C
+++ b/vrpn_nVidia_shield_controller.C
@@ -1,0 +1,301 @@
+// vrpn_nVidia_shield_controller.C: VRPN driver for nVidia shield devices
+
+#include <stdio.h>                      // for fprintf, stderr, NULL
+#include <string.h>                     // for memset
+#include <math.h>                       // for fabs
+
+#include "vrpn_nVidia_shield_controller.h"
+VRPN_SUPPRESS_EMPTY_OBJECT_WARNING()
+
+#if defined(VRPN_USE_HID)
+
+static const double POLL_INTERVAL = 1e+6 / 30.0;		// If we have not heard, report.
+
+// USB vendor and product IDs for the models we support
+static const vrpn_uint16 NVIDIA_VENDOR = 0x955;
+static const vrpn_uint16 NVIDIA_SHIELD_USB = 0x7210;
+
+vrpn_nVidia_shield::vrpn_nVidia_shield(vrpn_HidAcceptor *filter,
+    const char *name, vrpn_Connection *c,
+    vrpn_uint16 vendor, vrpn_uint16 product)
+  : vrpn_BaseClass(name, c)
+  , vrpn_HidInterface(filter, vendor, product)
+  , d_filter(filter)
+{
+	init_hid();
+}
+
+vrpn_nVidia_shield::~vrpn_nVidia_shield(void)
+{
+  delete d_filter;
+}
+
+void vrpn_nVidia_shield::init_hid(void) {
+}
+
+void vrpn_nVidia_shield::on_data_received(size_t bytes, vrpn_uint8 *buffer)
+{
+  decodePacket(bytes, buffer);
+}
+
+vrpn_nVidia_shield_USB::vrpn_nVidia_shield_USB(const char *name, vrpn_Connection *c)
+    : vrpn_nVidia_shield(d_filter = new vrpn_HidProductAcceptor(NVIDIA_VENDOR, NVIDIA_SHIELD_USB), name, c, NVIDIA_VENDOR, NVIDIA_SHIELD_USB)
+  , vrpn_Analog(name, c)
+  , vrpn_Button_Filter(name, c)
+{
+  vrpn_Analog::num_channel = 10;
+  vrpn_Button::num_buttons = 21;
+
+  // Initialize the state of all the analogs and buttons
+  memset(buttons, 0, sizeof(buttons));
+  memset(lastbuttons, 0, sizeof(lastbuttons));
+  memset(channel, 0, sizeof(channel));
+  memset(last, 0, sizeof(last));
+}
+
+void vrpn_nVidia_shield_USB::mainloop(void)
+{
+	update();
+	server_mainloop();
+	struct timeval current_time;
+	vrpn_gettimeofday(&current_time, NULL);
+	if (vrpn_TimevalDuration(current_time, d_timestamp) > POLL_INTERVAL ) {
+		d_timestamp = current_time;
+		report_changes();
+
+		if (vrpn_Analog::num_channel > 0)
+		{
+			vrpn_Analog::server_mainloop();
+		}
+		if (vrpn_Button::num_buttons > 0)
+		{
+			vrpn_Button::server_mainloop();
+		}
+	}
+}
+
+void vrpn_nVidia_shield_USB::report(vrpn_uint32 class_of_service) {
+	if (vrpn_Analog::num_channel > 0)
+	{
+		vrpn_Analog::timestamp = d_timestamp;
+	}
+	if (vrpn_Button::num_buttons > 0)
+	{
+		vrpn_Button::timestamp = d_timestamp;
+	}
+
+	if (vrpn_Analog::num_channel > 0)
+	{
+		vrpn_Analog::report(class_of_service);
+	}
+	if (vrpn_Button::num_buttons > 0)
+	{
+		vrpn_Button::report_changes();
+	}
+}
+
+void vrpn_nVidia_shield_USB::report_changes(vrpn_uint32 class_of_service) {
+	if (vrpn_Analog::num_channel > 0)
+	{
+		vrpn_Analog::timestamp = d_timestamp;
+	}
+	if (vrpn_Button::num_buttons > 0)
+	{
+		vrpn_Button::timestamp = d_timestamp;
+	}
+
+	if (vrpn_Analog::num_channel > 0)
+	{
+		vrpn_Analog::report_changes(class_of_service);
+	}
+	if (vrpn_Button::num_buttons > 0)
+	{
+		vrpn_Button::report_changes();
+	}
+}
+
+void vrpn_nVidia_shield_USB::decodePacket(size_t bytes, vrpn_uint8 *buffer)
+{
+  // There are two types of reports, type 1 is 15 bytes long (plus the
+  // type byte) and type 2 is 5 bytes long (plus the type byte)
+
+  if ( (bytes == 6) && (buffer[0] == 2) ) {
+
+    // 6-byte reports.  Thumb touch pad.
+    // Byte 0 is 02 (report type 2)
+    // Byte 1:
+    //   Bit 0: pad button pressed
+    //   Bit 7: finger touching pad
+    // Byte 2 seems to be X position, near 39 to left and near DF to right
+    // Byte 3 is 00
+    // Byte 4 seems to be Y position, near 33 at top and near 5B at bottom
+    // Byte 5 is 00
+
+    buttons[8] = ( (buffer[1] & (1 << 0)) != 0);
+    buttons[20] = ( (buffer[1] & (1 << 7)) != 0);
+    channel[6] = buffer[2] / 255.0;
+    channel[7] = buffer[4] / 255.0;
+
+  } else if ( (bytes == 16) && (buffer[0] == 1) ) {
+
+    // 16-byte reports.
+    // Byte 0 is 01 (report type 1)
+
+    // Byte 1:
+    //  Bit 0: A button
+    //  Bit 1: B button
+    //  Bit 2: X button
+    //  Bit 3: Y button
+    //  Bit 4: Left finger trigger button
+    //  Bit 5: Right finger trigger button
+    //  Bit 6: Left joystick button
+    //  Bit 7: Right joystick button
+    // Byte 2:
+    //  Bit 0: Touch pad button pressed or center of volume control pressed
+    //         or left of volume control pressed or right of volume control pressed
+    //  Bit 1: Play/pause button pressed
+    //  Bit 3: Right of volume control (+) pressed
+    //  Bit 4: Left of volume control (-) pressed
+    //  Bit 5: Shield emblem pressed
+    //  Bit 6: Go Back button pressed
+    //  Bit 7: Home button pressed
+
+    int first_byte = 1;
+    int num_bytes = 2;
+    int first_button = 0;
+    for (int byte = first_byte; byte < first_byte + num_bytes; byte++) {
+      vrpn_uint8 value = buffer[byte];
+      for (int btn = 0; btn < 8; btn++) {
+        vrpn_uint8 mask = static_cast<vrpn_uint8>(1 << btn);
+        buttons[8*(byte - first_byte) + btn + first_button] = ((value & mask) != 0);
+      }
+
+    }
+
+    // Byte 3: Left hi-hat:
+    //  0F: Nothing pressed
+    //  0 = North, 1 = NE, 2 = E, 3 = SE, 4 = S, 5 = SW, 6 = W, 7 = NW
+    //  This is encoded as buttons 16 (up), 17 (right), 18 (down), and 19 (left)
+    //  It is also encoded as two analogs: 8 (X, -1 left 1 right) and
+    //    9 (Y, -1 up 1 down).
+    switch (buffer[3]) {
+    case 0:
+      buttons[16] = 1;
+      buttons[17] = 0;
+      buttons[18] = 0;
+      buttons[19] = 0;
+      channel[8] = 0;
+      channel[9] = -1;
+      break;
+
+    case 1:
+      buttons[16] = 1;
+      buttons[17] = 1;
+      buttons[18] = 0;
+      buttons[19] = 0;
+      channel[8] = 1;
+      channel[9] = -1;
+      break;
+
+    case 2:
+      buttons[16] = 0;
+      buttons[17] = 1;
+      buttons[18] = 0;
+      buttons[19] = 0;
+      channel[8] = 1;
+      channel[9] = 0;
+      break;
+
+    case 3:
+      buttons[16] = 0;
+      buttons[17] = 1;
+      buttons[18] = 1;
+      buttons[19] = 0;
+      channel[8] = 1;
+      channel[9] = 1;
+      break;
+
+    case 4:
+      buttons[16] = 0;
+      buttons[17] = 0;
+      buttons[18] = 1;
+      buttons[19] = 0;
+      channel[8] = 0;
+      channel[9] = 1;
+      break;
+
+    case 5:
+      buttons[16] = 0;
+      buttons[17] = 0;
+      buttons[18] = 1;
+      buttons[19] = 1;
+      channel[8] = -1;
+      channel[9] = 1;
+      break;
+
+    case 6:
+      buttons[16] = 0;
+      buttons[17] = 0;
+      buttons[18] = 0;
+      buttons[19] = 1;
+      channel[8] = -1;
+      channel[9] = 0;
+      break;
+
+    case 7:
+      buttons[16] = 1;
+      buttons[17] = 0;
+      buttons[18] = 0;
+      buttons[19] = 1;
+      channel[8] = -1;
+      channel[9] = -1;
+      break;
+
+    default:
+      buttons[16] = 0;
+      buttons[17] = 0;
+      buttons[18] = 0;
+      buttons[19] = 0;
+      channel[8] = 0;
+      channel[9] = 0;
+      break;
+    }
+
+    // Left stick X axis is bytes 4-5, least byte first, FF 7F in middle
+    //  00 00 to left, FF FF to right
+    // Left stick Y axis is bytes 6-7, 00 00 is up and FF FF is down
+    // Right stick X axis is bytes 8-9, 00 00 is left
+    // Right stick Y axis is bytes 10-11, 00 00 is up
+    int first_joy_axis = 4;
+    int num_joy_axis = 4;
+    int first_analog = 0;
+    vrpn_uint8 *bufptr = &buffer[4];
+    for (int axis = first_joy_axis; axis < first_joy_axis + num_joy_axis; axis++) {
+      vrpn_uint16 raw_val = vrpn_unbuffer_from_little_endian<vrpn_uint16>(bufptr);
+      vrpn_int32 signed_val = raw_val - static_cast<int>(32767);
+      double value = signed_val / 32768.0;
+      channel[first_analog + axis - first_joy_axis] = value;
+    }
+
+    // Left analog finger trigger is bytes 12-13, 00 00 is out, FF FF is in
+    // Right analog finger trigger is bytes 14-15, 00 00 is out, FF FF is in
+    int first_trigger = 4;
+    int num_trigger = 2;
+    first_analog = 4;
+    bufptr = &buffer[12];
+    for (int trig = first_trigger; trig < first_trigger + num_trigger; trig++) {
+      vrpn_uint16 raw_val = vrpn_unbuffer_from_little_endian<vrpn_uint16>(bufptr);
+      double value = raw_val / 65535.0;
+      channel[first_analog + trig - first_trigger] = value;
+    }
+
+	} else {
+    vrpn_uint8 type = 0;
+    if (bytes > 0) { type = buffer[0]; }
+		fprintf(stderr, "vrpn_nVidia_shield_USB: Unrecognized report type (%u); # total bytes = %u\n", type, static_cast<unsigned>(bytes));
+	}
+
+}
+
+// End of VRPN_USE_HID
+#endif

--- a/vrpn_nVidia_shield_controller.C
+++ b/vrpn_nVidia_shield_controller.C
@@ -118,8 +118,10 @@ void vrpn_nVidia_shield_USB::decodePacket(size_t bytes, vrpn_uint8 *buffer)
 {
   // There are two types of reports, type 1 is 15 bytes long (plus the
   // type byte) and type 2 is 5 bytes long (plus the type byte)
+  // (On Linux, this shows up as a 16-byte message, even when it is
+  // type 2, on the mac it shows up as 6.)
 
-  if ( (bytes == 6) && (buffer[0] == 2) ) {
+  if ( (bytes >= 6) && (buffer[0] == 2) ) {
 
     // 6-byte reports.  Thumb touch pad.
     // Byte 0 is 02 (report type 2)

--- a/vrpn_nVidia_shield_controller.h
+++ b/vrpn_nVidia_shield_controller.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <stddef.h>                     // for size_t
+
+#include "vrpn_Analog.h"                // for vrpn_Analog
+#include "vrpn_Button.h"                // for vrpn_Button_Filter
+#include "vrpn_HumanInterface.h"        // for vrpn_HidAcceptor (ptr only), etc
+
+#if defined(VRPN_USE_HID)
+
+// Device drivers for the nVidia Shield controller line of products
+// Currently supported: Shield controller plugged into USB
+
+class vrpn_nVidia_shield: public vrpn_BaseClass, protected vrpn_HidInterface {
+public:
+  vrpn_nVidia_shield(vrpn_HidAcceptor *filter, const char *name, vrpn_Connection *c = 0,
+      vrpn_uint16 vendor = 0, vrpn_uint16 product = 0);
+  virtual ~vrpn_nVidia_shield(void);
+
+  virtual void mainloop(void) = 0;
+
+protected:
+  // Set up message handlers, etc.
+  void init_hid(void);
+  void on_data_received(size_t bytes, vrpn_uint8 *buffer);
+
+  virtual void decodePacket(size_t bytes, vrpn_uint8 *buffer) = 0;	
+  struct timeval d_timestamp;
+  vrpn_HidAcceptor *d_filter;
+
+  // No actual types to register, derived classes will be buttons or analogs
+  int register_types(void) { return 0; }
+};
+
+class vrpn_nVidia_shield_USB: protected vrpn_nVidia_shield,
+    public vrpn_Analog, public vrpn_Button_Filter {
+public:
+  vrpn_nVidia_shield_USB(const char *name, vrpn_Connection *c = 0);
+  virtual ~vrpn_nVidia_shield_USB(void) {};
+
+  virtual void mainloop(void);
+
+protected:
+  // Send report iff changed
+  void report_changes (vrpn_uint32 class_of_service = vrpn_CONNECTION_LOW_LATENCY);
+  // Send report whether or not changed
+  void report (vrpn_uint32 class_of_service = vrpn_CONNECTION_LOW_LATENCY);
+
+  void decodePacket(size_t bytes, vrpn_uint8 *buffer);
+};
+
+// end of VRPN_USE_HID
+#else
+class VRPN_API vrpn_nVidia_shield;
+class VRPN_API vrpn_nVidia_shield_USB;
+#endif
+

--- a/vrpndll.vcproj
+++ b/vrpndll.vcproj
@@ -1536,6 +1536,46 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="vrpn_nVidia_shield_controller.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="vrpn_Oculus.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="vrpn_OmegaTemperature.C"
 				>
 				<FileConfiguration
@@ -1956,26 +1996,6 @@
 				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="vrpn_Tracker_IMU.C"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						CompileAs="2"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						CompileAs="2"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
 				RelativePath="vrpn_Tracker_AnalogFly.C"
 				>
 				<FileConfiguration
@@ -2156,6 +2176,26 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="vrpn_Tracker_IMU.C"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						CompileAs="2"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="vrpn_Tracker_isense.C"
 				>
 				<FileConfiguration
@@ -2297,26 +2337,6 @@
 			</File>
 			<File
 				RelativePath="vrpn_Tracker_NovintFalcon.C"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						CompileAs="2"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						CompileAs="2"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="vrpn_Oculus.C"
 				>
 				<FileConfiguration
 					Name="Release|Win32"
@@ -3013,6 +3033,14 @@
 				>
 			</File>
 			<File
+				RelativePath="vrpn_nVidia_shield_controller.h"
+				>
+			</File>
+			<File
+				RelativePath="vrpn_Oculus.h"
+				>
+			</File>
+			<File
 				RelativePath="vrpn_OmegaTemperature.h"
 				>
 			</File>
@@ -3109,10 +3137,6 @@
 				>
 			</File>
 			<File
-				RelativePath="vrpn_Tracker_IMU.h"
-				>
-			</File>
-			<File
 				RelativePath="vrpn_Tracker_ButtonFly.h"
 				>
 			</File>
@@ -3145,6 +3169,10 @@
 				>
 			</File>
 			<File
+				RelativePath="vrpn_Tracker_IMU.h"
+				>
+			</File>
+			<File
 				RelativePath="vrpn_Tracker_isense.h"
 				>
 			</File>
@@ -3174,10 +3202,6 @@
 			</File>
 			<File
 				RelativePath="vrpn_Tracker_NovintFalcon.h"
-				>
-			</File>
-			<File
-				RelativePath="vrpn_Oculus.h"
 				>
 			</File>
 			<File


### PR DESCRIPTION
nVidia Shield controller driver added, for the device plugged into a computer using the USB interface.  Tested on Linux, Windows 8.1, and mac.  On Windows, the touch panel drives the mouse and does not generate reports to VRPN.  On mac, the device tries to shut down the mac when plugged in, the volume controls control volume, and pressing the shield puts the mac to sleep but the events do seem to get passed along.  On Linux, all events show up and no OS impact is seen.