### PR TITLE
Remove another explicit setting of CMAKE_OSX_ARCHITECTURES

### DIFF
--- a/quat/CMakeLists.txt
+++ b/quat/CMakeLists.txt
@@ -2,30 +2,10 @@ cmake_minimum_required(VERSION 2.6)
 project(quatlib)
 
 if(APPLE)
-	if(NOT CMAKE_OSX_ARCHITECTURES OR CMAKE_OSX_ARCHITECTURES STREQUAL "")
-		if(_CMAKE_OSX_MACHINE MATCHES "ppc")
-			set(CMAKE_OSX_ARCHITECTURES
-				"ppc;ppc64"
-				CACHE
-				STRING
-				"Build architectures for OS X"
-				FORCE)
-		else()
-			set(CMAKE_OSX_ARCHITECTURES
-				"i386;x86_64"
-				CACHE
-				STRING
-				"Build architectures for OS X"
-				FORCE)
-		endif()
-	endif()
-	set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-isystem ")
-	set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
+	# XXX Is this still needed?
 	if(NOT CMAKE_INSTALL_NAME_DIR)
 		set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
 	endif()
-	message(STATUS
-		"Building ${CMAKE_PROJECT_NAME} for ${CMAKE_OSX_ARCHITECTURES}")
 endif()
 
 set(QUATLIB_SOURCES matrix.c quat.c vector.c xyzquat.c)


### PR DESCRIPTION
This resolves another instance of setting CMAKE_OSX_ARCHITECTURES explicitly. This was previously fixed in the main CMakeLists.txt at https://github.com/vrpn/vrpn/issues/113.