### PR TITLE
Update hidapi to latest upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submodules/hidapi"]
 	path = submodules/hidapi
-	url = https://github.com/vrpn/hidapi.git
+	url = https://github.com/signal11/hidapi.git
 [submodule "submodules/jsoncpp"]
 	path = submodules/jsoncpp
 	url = https://github.com/vrpn/jsoncpp.git


### PR DESCRIPTION
This updates hidapi to the latest upstream and should resolve https://github.com/vrpn/vrpn/issues/95 and https://github.com/vrpn/vrpn/issues/123. Looking more closely, the change in enumeration semantics should not affect us, but this needs to be tested on Windows. This also changes the remote for hidapi to the upstream remote as the commit that's in the forked version was merged upstream.

This is necessary for OSVR to work at all on Mac OS X — right now it just crashes.