### PR TITLE
Add Oculus DK1 support

### DIFF
--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -3059,8 +3059,8 @@
 #vrpn_Tracker_OSVRHackerDevKit Tracker0
 
 ################################################################################
-# There are two versions of this driver, which use the same hardware but it
-# two different modes.
+# Oculus Rift DK1 and DK2. There are two versions of the DK2  driver, which use the 
+# same hardware but in two different modes.
 #
 # vrpn_Oculus_DK2_inertial: Oculus DK2 inertial measurement unit only.  This
 #  provides access to the magnetometer readings on the unit and has a different
@@ -3116,6 +3116,7 @@
 # Arguments:
 #	char	name_of_this_device[]
 
+#vrpn_Oculus_DK1 Oculus0
 #vrpn_Oculus_DK2_inertial Oculus0
 #vrpn_Oculus_DK2_LEDs Oculus0
 

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -55,7 +55,7 @@
 #include "vrpn_Mouse.h"                    // for vrpn_Button_SerialMouse, etc
 #include "vrpn_NationalInstruments.h"
 #include "vrpn_nikon_controls.h"   // for vrpn_Nikon_Controls
-#include "vrpn_Oculus.h"           // for vrpn_Oculus_DK2
+#include "vrpn_Oculus.h"           // for vrpn_Oculus
 #include "vrpn_OmegaTemperature.h" // for vrpn_OmegaTemperature
 #include "vrpn_Phantom.h"
 #include "vrpn_Poser_Analog.h"          // for vrpn_Poser_AnalogParam, etc
@@ -4811,6 +4811,32 @@ int vrpn_Generic_Server_Object::setup_Tracker_DeadReckoning_Rotation(char *&pch,
     return 0;
 }
 
+int vrpn_Generic_Server_Object::setup_Oculus_DK1(char *&pch, char *line, FILE *)
+{
+  char s2[LINESIZE];
+
+  VRPN_CONFIG_NEXT();
+  int ret = sscanf(pch, "%511s", s2);
+  if (ret != 1) {
+    fprintf(stderr, "Bad Oculus_DK1 line: %s\n", line);
+    return -1;
+  }
+
+  // Open the Oculus DK2
+  if (verbose) {
+    printf("Opening vrpn_Oculus_DK1\n");
+  }
+
+#ifdef VRPN_USE_HID
+  // Open the tracker
+  _devices->add(new vrpn_Oculus_DK1(s2, connection));
+#else
+  fprintf(stderr,
+    "Oculus_DK1 driver works only with VRPN_USE_HID defined!\n");
+#endif
+  return 0; // successful completion
+}
+
 int vrpn_Generic_Server_Object::setup_Oculus_DK2_LEDs(char *&pch, char *line, FILE *)
 {
   char s2[LINESIZE];
@@ -5574,6 +5600,9 @@ vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
                 }
                 else if (VRPN_ISIT("vrpn_Tracker_DeadReckoning_Rotation")) {
                     VRPN_CHECK(setup_Tracker_DeadReckoning_Rotation);
+                }
+                else if (VRPN_ISIT("vrpn_Oculus_DK1")) {
+                  VRPN_CHECK(setup_Oculus_DK1);
                 }
                 else if (VRPN_ISIT("vrpn_Oculus_DK2_LEDs")) {
                   VRPN_CHECK(setup_Oculus_DK2_LEDs);

--- a/server_src/vrpn_Generic_server_object.h
+++ b/server_src/vrpn_Generic_server_object.h
@@ -160,6 +160,7 @@ protected:
     int setup_YEI_3Space_Sensor(char *&pch, char *line, FILE *config_file);
     int setup_YEI_3Space_Sensor_Wireless(char *&pch, char *line, FILE *config_file);
     int setup_Tracker_ThalmicLabsMyo(char * &pch, char *line, FILE * config_file);
+    int setup_Oculus_DK1(char *&pch, char *line, FILE *config_file);
     int setup_Oculus_DK2_LEDs(char *&pch, char *line, FILE *config_file);
     int setup_Oculus_DK2_inertial(char *&pch, char *line, FILE *config_file);
     int setup_IMU_Magnetometer(char *&pch, char *line, FILE *config_file);

--- a/vrpn_Oculus.h
+++ b/vrpn_Oculus.h
@@ -1,5 +1,5 @@
 /** @file	vrpn_Oculus.h
-	@brief	Header for various Oculus devices.  Initially, just the DK2.
+	@brief	Header for various Oculus devices.  Initially, just the DK1 & DK2.
 
 	@date	2015
   @copyright 2015 ReliaSolve.com
@@ -17,41 +17,38 @@
 
 #if defined(VRPN_USE_HID)
 
-/// @brief Oculus Rift DK2 head-mounted display base class for both intertial-
-/// only and LED-enabled version.
-class VRPN_API vrpn_Oculus_DK2 : public vrpn_Analog, protected vrpn_HidInterface {
+/// @brief Oculus Rift head-mounted display base class 
+class VRPN_API vrpn_Oculus : public vrpn_Analog, protected vrpn_HidInterface {
 public:
     /**
      * @brief Destructor.
      */
-    virtual ~vrpn_Oculus_DK2();
+    virtual ~vrpn_Oculus();
 
     virtual void mainloop();
 
 protected:
   /**
-  * @brief Protected constructor so you can't instantiate this base class.
-  *
-  * @param name Name of this device.
-  * @param c Optional vrpn_Connection pointer to use as our connection.
-  * @param keepAliveSeconds How often to re-trigger the LED flashing
-  */
-  vrpn_Oculus_DK2(bool enableLEDs, const char *name, vrpn_Connection *c = NULL,
-    double keepAliveSeconds = 9.0);
+   * @brief Protected constructor so you can't instantiate this base class.
+   *
+   * @param product_id USB Device ID for this device.
+   * @param num_channels Number of analog channels on the device.
+   * @param name Name of the device.
+   * @param c Optional vrpn_Connection pointer to use as our connection.
+   * @param keepAliveSeconds How often to send keepalive message
+   */
+  vrpn_Oculus(vrpn_uint16 product_id, vrpn_uint8 num_channels, 
+      const char *name, vrpn_Connection *c = NULL, double keepAliveSeconds = 9.0);
 
   vrpn_HidAcceptor *m_filter;
 
   //-------------------------------------------------------------
-  // Parsers for different report types.  The DK2 sends type-1
-  // reports in response to inertial-only keep-alive messages
-  // and type-11 reports in response to LED-enabled keep-alive
-  // messages.
+  // Parsers for different report types.  
+  // Override to define more parsers
+  virtual bool parse_message(std::size_t bytes, vrpn_uint8 *buffer);
 
   /// Parse and send reports for type-1 message
   void parse_message_type_1(std::size_t bytes, vrpn_uint8 *buffer);
-
-  /// Parse and send reports for type-11 message
-  void parse_message_type_11(std::size_t bytes, vrpn_uint8 *buffer);
 
   /// Extracts the sensor values from each report and calls the
   /// appropriate parser.
@@ -60,17 +57,73 @@ protected:
   /// Timestamp updated during mainloop()
   struct timeval d_timestamp;
 
-  /// How often to send the keepAlive message to trigger the LEDs
-  bool d_enableLEDs;
+  /// How often to send the keepAlive message to the Rift (triggers
+  /// the LEDs if available)
   double d_keepAliveSeconds;
   struct timeval d_lastKeepAlive;
 
-  // Send a KeepAlive feature report to the DK2.  This needs to be sent
-  // every keepAliveSeconds to keep the LEDs going.
-  void writeKeepAlive(
-    vrpn_uint16 interval = 10000 //< KeepAlive time in milliseconds
-    , vrpn_uint16 commandId = 0 //< Should always be zero
-    );
+  // Send a KeepAlive feature report to the Rift.
+  virtual void writeKeepAlive(
+      vrpn_uint16 interval = 10000 //< KeepAlive time in milliseconds
+      , vrpn_uint16 commandId = 0 //< Should always be zero
+      ) = 0;
+};
+
+/// @brief Oculus Rift DK1 head-mounted display
+class VRPN_API vrpn_Oculus_DK1 : public vrpn_Oculus {
+public:
+  /**
+   * @brief Constructor
+   *
+   * @param name Name of this device.
+   * @param c Optional vrpn_Connection pointer to use as our connection.
+   * @param keepAliveSeconds How often to re-trigger the LED flashing
+   */
+  vrpn_Oculus_DK1(const char *name, vrpn_Connection *c = NULL,
+      double keepAliveSeconds = 9.0);
+
+protected:
+
+  // Send a KeepAlive feature report to the Rift.
+  virtual void writeKeepAlive(
+      vrpn_uint16 interval = 10000 //< KeepAlive time in milliseconds
+      , vrpn_uint16 commandId = 0 //< Should always be zero
+      );
+};
+
+/// @brief Oculus Rift DK2 head-mounted display base class for both intertial-
+/// only and LED-enabled version.
+class VRPN_API vrpn_Oculus_DK2 : public vrpn_Oculus {
+protected:
+  /**
+   * @brief Protected constructor so you can't instantiate this base class.
+   *
+   * @param name Name of this device.
+   * @param c Optional vrpn_Connection pointer to use as our connection.
+   * @param keepAliveSeconds How often to re-trigger the LED flashing
+   */
+  vrpn_Oculus_DK2(bool enableLEDs, const char *name, vrpn_Connection *c = NULL,
+      double keepAliveSeconds = 9.0);
+
+  //-------------------------------------------------------------
+  // Parsers for different report types.  The DK2 sends type-1
+  // reports in response to inertial-only keep-alive messages
+  // and type-11 reports in response to LED-enabled keep-alive
+  // messages.
+  //
+  bool parse_message(std::size_t bytes, vrpn_uint8 *buffer);
+
+  /// Parse and send reports for type-11 message
+  void parse_message_type_11(std::size_t bytes, vrpn_uint8 *buffer);
+
+  /// Whether to trigger the LEDs
+  bool d_enableLEDs;
+
+  // Send a KeepAlive feature report to the Rift.
+  virtual void writeKeepAlive(
+      vrpn_uint16 interval = 10000 //< KeepAlive time in milliseconds
+      , vrpn_uint16 commandId = 0 //< Should always be zero
+      );
 };
 
 /// @brief Oculus Rift DK2 head-mounted display (inertial measurement unit only)


### PR DESCRIPTION
Further to https://github.com/vrpn/vrpn/pull/119, adds support for Oculus DK1.

Should this be handling calibration or is that left to the client? My unit shows nasty yaw drift, the same as it did in Vrui before calibration.