### PR TITLE
cmake: set the soversion on the libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1262,6 +1262,11 @@ if(VRPN_BUILD_SERVER_LIBRARY)
 	set_property(TARGET
 		vrpnserver
 		PROPERTY
+		SOVERSION
+		0)
+	set_property(TARGET
+		vrpnserver
+		PROPERTY
 		PROJECT_LABEL
 		"Core VRPN Server Library")
 	set_property(TARGET
@@ -1305,6 +1310,11 @@ if(VRPN_BUILD_CLIENT_LIBRARY)
 		PROPERTY
 		PUBLIC_HEADER
 		${VRPN_CLIENT_PUBLIC_HEADERS})
+	set_property(TARGET
+		vrpn
+		PROPERTY
+		SOVERSION
+		0)
 
 	if(NOT VRPN_CLIENT_ONLY)
 		set_property(TARGET


### PR DESCRIPTION
This creates libvrpn.so.0 libraries which are typically used as the file
with the actual code. The libvrpn.so is then a symlink which is used in
development files so that -lvrpn works. Same for the server library.

This number should be bumped for ABI breaks (removal of old functions,
symbol renames, etc.).

Not required for the plain-Make build since it only builds static
libraries.
