### PR TITLE
Mac lint

### DIFF
--- a/time_test.cpp
+++ b/time_test.cpp
@@ -133,7 +133,8 @@ int main(void)
   double skip;
   vrpn_gettimeofday(&last_time, NULL);
   printf("Current time in seconds:microseconds = %lu:%lu\n", 
-    last_time.tv_sec, last_time.tv_usec);
+    static_cast<unsigned long>(last_time.tv_sec),
+    static_cast<unsigned long>(last_time.tv_usec) );
   
   printf("Checking for monotonicity and step size\n");
   printf(" (should be no further output if things are working perfectly)\n");

--- a/vrpn_3DConnexion.C
+++ b/vrpn_3DConnexion.C
@@ -312,46 +312,46 @@ void vrpn_3DConnexion::decodePacket(size_t bytes, vrpn_uint8 *buffer)
 #endif
 
 vrpn_3DConnexion_Navigator::vrpn_3DConnexion_Navigator(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR), 2, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR), 2, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR)
 {
 }
 
 vrpn_3DConnexion_Navigator_for_Notebooks::vrpn_3DConnexion_Navigator_for_Notebooks(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR_FOR_NOTEBOOKS), 2, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR_FOR_NOTEBOOKS)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR_FOR_NOTEBOOKS), 2, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_NAVIGATOR_FOR_NOTEBOOKS)
 {
 }
 
 vrpn_3DConnexion_Traveler::vrpn_3DConnexion_Traveler(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_TRAVELER), 8, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_TRAVELER)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_TRAVELER), 8, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_TRAVELER)
 {
 }
 
 vrpn_3DConnexion_SpaceMouse::vrpn_3DConnexion_SpaceMouse(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSE), 11, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSE)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSE), 11, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSE)
 {
 }
 
 vrpn_3DConnexion_SpaceMousePro::vrpn_3DConnexion_SpaceMousePro(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEPRO), 27, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEPRO)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEPRO), 27, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEPRO)
 {	// 15 physical buttons are numbered: 0-2, 4-5, 8, 12-15, 22-26
 }
 
 vrpn_3DConnexion_SpaceMouseWireless::vrpn_3DConnexion_SpaceMouseWireless(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEWIRELESS), 2, name, c, vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEWIRELESS)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEWIRELESS), 2, name, c, vrpn_SPACEMOUSEWIRELESS_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEWIRELESS)
 {
 }
 
 vrpn_3DConnexion_SpaceExplorer::vrpn_3DConnexion_SpaceExplorer(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEEXPLORER), 15, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEEXPLORER)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEEXPLORER), 15, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEEXPLORER)
 {
 }
 
 vrpn_3DConnexion_SpaceBall5000::vrpn_3DConnexion_SpaceBall5000(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEBALL5000), 12, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEBALL5000)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEBALL5000), 12, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEBALL5000)
 {
 }
 
 vrpn_3DConnexion_SpacePilot::vrpn_3DConnexion_SpacePilot(const char *name, vrpn_Connection *c)
-    : vrpn_3DConnexion(_filter = new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEPILOT), 21, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEPILOT)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEPILOT), 21, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEPILOT)
 {
 }

--- a/vrpn_CHProducts_Controller_Raw.C
+++ b/vrpn_CHProducts_Controller_Raw.C
@@ -108,7 +108,7 @@ int vrpn_CHProducts_Controller_Raw::on_connect(void* /* thisPtr */, vrpn_HANDLER
 // ST290 Pro Joystick
 //////////////////////////////////////////////////////////////////////////
 vrpn_CHProducts_Fighterstick_USB::vrpn_CHProducts_Fighterstick_USB(const char *name, vrpn_Connection *c) :
-vrpn_CHProducts_Controller_Raw(_filter = new vrpn_HidProductAcceptor(CHPRODUCTS_VENDOR, FIGHTERSTICK_USB), name, c, CHPRODUCTS_VENDOR, FIGHTERSTICK_USB),
+vrpn_CHProducts_Controller_Raw(new vrpn_HidProductAcceptor(CHPRODUCTS_VENDOR, FIGHTERSTICK_USB), name, c, CHPRODUCTS_VENDOR, FIGHTERSTICK_USB),
 	vrpn_Analog(name, c), vrpn_Button_Filter(name, c), vrpn_Dial(name, c)
 {
 	vrpn_Analog::num_channel = 8;

--- a/vrpn_Contour.C
+++ b/vrpn_Contour.C
@@ -70,7 +70,7 @@ int vrpn_Contour::on_connect(void* /*thisPtr*/, vrpn_HANDLERPARAM /*p*/)
 }
 
 vrpn_Contour_ShuttleXpress::vrpn_Contour_ShuttleXpress(const char *name, vrpn_Connection *c)
-    : vrpn_Contour(_filter = new vrpn_HidProductAcceptor(CONTOUR_VENDOR, CONTOUR_SHUTTLEXPRESS), name, c, CONTOUR_VENDOR, CONTOUR_SHUTTLEXPRESS)
+    : vrpn_Contour(new vrpn_HidProductAcceptor(CONTOUR_VENDOR, CONTOUR_SHUTTLEXPRESS), name, c, CONTOUR_VENDOR, CONTOUR_SHUTTLEXPRESS)
   , vrpn_Analog(name, c)
   , vrpn_Button_Filter(name, c)
   , vrpn_Dial(name, c)
@@ -206,7 +206,7 @@ void vrpn_Contour_ShuttleXpress::decodePacket(size_t bytes, vrpn_uint8 *buffer) 
 
 
 vrpn_Contour_ShuttlePROv2::vrpn_Contour_ShuttlePROv2(const char *name, vrpn_Connection *c)
-    : vrpn_Contour(_filter = new vrpn_HidProductAcceptor(CONTOUR_VENDOR, CONTOUR_SHUTTLEPROV2), name, c, CONTOUR_VENDOR, CONTOUR_SHUTTLEPROV2)
+    : vrpn_Contour(new vrpn_HidProductAcceptor(CONTOUR_VENDOR, CONTOUR_SHUTTLEPROV2), name, c, CONTOUR_VENDOR, CONTOUR_SHUTTLEPROV2)
 	, vrpn_Analog(name, c)
 	, vrpn_Button_Filter(name, c)
 	, vrpn_Dial(name, c)

--- a/vrpn_DreamCheeky.C
+++ b/vrpn_DreamCheeky.C
@@ -35,7 +35,7 @@ void vrpn_DreamCheeky::on_data_received(size_t bytes, vrpn_uint8 *buffer)
 
 vrpn_DreamCheeky_Drum_Kit::vrpn_DreamCheeky_Drum_Kit(const char *name, vrpn_Connection *c,
                                                      bool debounce)
-                                                     : vrpn_DreamCheeky(_filter = new vrpn_HidProductAcceptor(DREAMCHEEKY_VENDOR, USB_ROLL_UP_DRUM_KIT), name, c, DREAMCHEEKY_VENDOR, USB_ROLL_UP_DRUM_KIT)
+                                                     : vrpn_DreamCheeky(new vrpn_HidProductAcceptor(DREAMCHEEKY_VENDOR, USB_ROLL_UP_DRUM_KIT), name, c, DREAMCHEEKY_VENDOR, USB_ROLL_UP_DRUM_KIT)
   , vrpn_Button_Filter(name, c)
   , d_debounce(debounce)
 {

--- a/vrpn_Futaba.C
+++ b/vrpn_Futaba.C
@@ -72,7 +72,7 @@ int vrpn_Futaba::on_connect(void* /*thisPtr*/, vrpn_HANDLERPARAM /*p*/)
 }
 
 vrpn_Futaba_InterLink_Elite::vrpn_Futaba_InterLink_Elite(const char *name, vrpn_Connection *c)
-    : vrpn_Futaba(_filter = new vrpn_HidProductAcceptor(FUTABA_VENDOR, FUTABA_ELITE), name, c, FUTABA_VENDOR, FUTABA_ELITE)
+    : vrpn_Futaba(new vrpn_HidProductAcceptor(FUTABA_VENDOR, FUTABA_ELITE), name, c, FUTABA_VENDOR, FUTABA_ELITE)
   , vrpn_Analog(name, c)
   , vrpn_Button_Filter(name, c)
   , vrpn_Dial(name, c)

--- a/vrpn_Griffin.C
+++ b/vrpn_Griffin.C
@@ -67,7 +67,7 @@ int vrpn_Griffin::on_connect(void* /*thisPtr*/, vrpn_HANDLERPARAM /*p*/)
 }
 
 vrpn_Griffin_PowerMate::vrpn_Griffin_PowerMate(const char *name, vrpn_Connection *c)
-    : vrpn_Griffin(_filter = new vrpn_HidProductAcceptor(GRIFFIN_VENDOR, GRIFFIN_POWERMATE), name, c, GRIFFIN_VENDOR, GRIFFIN_POWERMATE)
+    : vrpn_Griffin(new vrpn_HidProductAcceptor(GRIFFIN_VENDOR, GRIFFIN_POWERMATE), name, c, GRIFFIN_VENDOR, GRIFFIN_POWERMATE)
   , vrpn_Analog(name, c)
   , vrpn_Button_Filter(name, c)
   , vrpn_Dial(name, c)

--- a/vrpn_Logitech_Controller_Raw.C
+++ b/vrpn_Logitech_Controller_Raw.C
@@ -109,7 +109,7 @@ int vrpn_Logitech_Controller_Raw::on_connect(void* /*thisPtr*/, vrpn_HANDLERPARA
 // SideWinder Precision 2 Joystick
 //////////////////////////////////////////////////////////////////////////
 vrpn_Logitech_Extreme_3D_Pro::vrpn_Logitech_Extreme_3D_Pro(const char *name, vrpn_Connection *c) :
-vrpn_Logitech_Controller_Raw(_filter = new vrpn_HidProductAcceptor(LOGITECH_VENDOR, EXTREME_3D_PRO), name, c, LOGITECH_VENDOR, EXTREME_3D_PRO),
+vrpn_Logitech_Controller_Raw(new vrpn_HidProductAcceptor(LOGITECH_VENDOR, EXTREME_3D_PRO), name, c, LOGITECH_VENDOR, EXTREME_3D_PRO),
 	vrpn_Analog(name, c), vrpn_Button_Filter(name, c), vrpn_Dial(name, c)
 {
 	vrpn_Analog::num_channel = 5;

--- a/vrpn_Microsoft_Controller_Raw.C
+++ b/vrpn_Microsoft_Controller_Raw.C
@@ -161,7 +161,7 @@ int vrpn_Microsoft_Controller_Raw::on_connect(void* /*thisPtr*/, vrpn_HANDLERPAR
 // SideWinder Precision 2 Joystick
 //////////////////////////////////////////////////////////////////////////
 vrpn_Microsoft_SideWinder_Precision_2::vrpn_Microsoft_SideWinder_Precision_2(const char *name, vrpn_Connection *c) :
-vrpn_Microsoft_Controller_Raw(_filter = new vrpn_HidProductAcceptor(MICROSOFT_VENDOR, SIDEWINDER_PRECISION_2), name, c, MICROSOFT_VENDOR, SIDEWINDER_PRECISION_2),
+vrpn_Microsoft_Controller_Raw(new vrpn_HidProductAcceptor(MICROSOFT_VENDOR, SIDEWINDER_PRECISION_2), name, c, MICROSOFT_VENDOR, SIDEWINDER_PRECISION_2),
 	vrpn_Analog(name, c), vrpn_Button_Filter(name, c), vrpn_Dial(name, c)
 {
 	vrpn_Analog::num_channel = 5;
@@ -305,7 +305,7 @@ void vrpn_Microsoft_SideWinder_Precision_2::decodePacket(size_t bytes, vrpn_uint
 // SideWinder Joystick
 //////////////////////////////////////////////////////////////////////////
 vrpn_Microsoft_SideWinder::vrpn_Microsoft_SideWinder(const char *name, vrpn_Connection *c) :
-vrpn_Microsoft_Controller_Raw(_filter = new vrpn_HidProductAcceptor(MICROSOFT_VENDOR, SIDEWINDER), name, c, MICROSOFT_VENDOR, SIDEWINDER),
+vrpn_Microsoft_Controller_Raw(new vrpn_HidProductAcceptor(MICROSOFT_VENDOR, SIDEWINDER), name, c, MICROSOFT_VENDOR, SIDEWINDER),
 	vrpn_Analog(name, c), vrpn_Button_Filter(name, c), vrpn_Dial(name, c)
 {
 	vrpn_Analog::num_channel = 3;
@@ -411,7 +411,7 @@ void vrpn_Microsoft_SideWinder::decodePacket(size_t bytes, vrpn_uint8 *buffer)
 // Xbox S
 //////////////////////////////////////////////////////////////////////////
 vrpn_Microsoft_Controller_Raw_Xbox_S::vrpn_Microsoft_Controller_Raw_Xbox_S(const char *name, vrpn_Connection *c)
-    : vrpn_Microsoft_Controller_Raw(_filter = new vrpn_HidProductAcceptor(MICROSOFT_VENDOR, XBOX_S), name, c, MICROSOFT_VENDOR, XBOX_S)
+    : vrpn_Microsoft_Controller_Raw(new vrpn_HidProductAcceptor(MICROSOFT_VENDOR, XBOX_S), name, c, MICROSOFT_VENDOR, XBOX_S)
   , vrpn_Analog(name, c)
   , vrpn_Button_Filter(name, c)
   , vrpn_Dial(name, c)
@@ -656,7 +656,7 @@ void vrpn_Microsoft_Controller_Raw_Xbox_S::decodePacket(size_t bytes, vrpn_uint8
 // Xbox 360
 //////////////////////////////////////////////////////////////////////////
 vrpn_Microsoft_Controller_Raw_Xbox_360_base::vrpn_Microsoft_Controller_Raw_Xbox_360_base(const char *name, vrpn_Connection *c, vrpn_uint16 vendor, vrpn_uint16 product)
-    : vrpn_Microsoft_Controller_Raw(_filter = new vrpn_HidProductAcceptor(vendor, product), name, c, vendor, product)
+    : vrpn_Microsoft_Controller_Raw(new vrpn_HidProductAcceptor(vendor, product), name, c, vendor, product)
 , vrpn_Analog(name, c)
 , vrpn_Button_Filter(name, c)
 , vrpn_Dial(name, c)

--- a/vrpn_Retrolink.C
+++ b/vrpn_Retrolink.C
@@ -118,7 +118,7 @@ int vrpn_Retrolink::on_connect(void* /*thisPtr*/, vrpn_HANDLERPARAM /*p*/)
 }
 
 vrpn_Retrolink_GameCube::vrpn_Retrolink_GameCube(const char *name, vrpn_Connection *c)
-    : vrpn_Retrolink(_filter = new vrpn_HidProductAcceptor(RETROLINK_VENDOR, RETROLINK_GAMECUBE), name, c, RETROLINK_VENDOR, RETROLINK_GAMECUBE)
+    : vrpn_Retrolink(new vrpn_HidProductAcceptor(RETROLINK_VENDOR, RETROLINK_GAMECUBE), name, c, RETROLINK_VENDOR, RETROLINK_GAMECUBE)
   , vrpn_Analog(name, c)
   , vrpn_Button_Filter(name, c)
 {
@@ -257,7 +257,7 @@ void vrpn_Retrolink_GameCube::decodePacket(size_t bytes, vrpn_uint8 *buffer)
 }
 
 vrpn_Retrolink_Genesis::vrpn_Retrolink_Genesis(const char *name, vrpn_Connection *c)
-    : vrpn_Retrolink(_filter = new vrpn_HidProductAcceptor(RETROLINK_VENDOR, RETROLINK_GENESIS), name, c, RETROLINK_VENDOR, RETROLINK_GENESIS)
+    : vrpn_Retrolink(new vrpn_HidProductAcceptor(RETROLINK_VENDOR, RETROLINK_GENESIS), name, c, RETROLINK_VENDOR, RETROLINK_GENESIS)
   , vrpn_Analog(name, c)
   , vrpn_Button_Filter(name, c)
 {

--- a/vrpn_Saitek_Controller_Raw.C
+++ b/vrpn_Saitek_Controller_Raw.C
@@ -108,7 +108,7 @@ int vrpn_Saitek_Controller_Raw::on_connect(void* /*thisPtr*/, vrpn_HANDLERPARAM 
 // ST290 Pro Joystick
 //////////////////////////////////////////////////////////////////////////
 vrpn_Saitek_ST290_Pro::vrpn_Saitek_ST290_Pro(const char *name, vrpn_Connection *c) :
-vrpn_Saitek_Controller_Raw(_filter = new vrpn_HidProductAcceptor(SAITEK_VENDOR, ST290_PRO), name, c, SAITEK_VENDOR, ST290_PRO),
+vrpn_Saitek_Controller_Raw(new vrpn_HidProductAcceptor(SAITEK_VENDOR, ST290_PRO), name, c, SAITEK_VENDOR, ST290_PRO),
 	vrpn_Analog(name, c), vrpn_Button_Filter(name, c), vrpn_Dial(name, c)
 {
 	vrpn_Analog::num_channel = 5;

--- a/vrpn_nVidia_shield_controller.C
+++ b/vrpn_nVidia_shield_controller.C
@@ -39,7 +39,7 @@ void vrpn_nVidia_shield::on_data_received(size_t bytes, vrpn_uint8 *buffer)
 }
 
 vrpn_nVidia_shield_USB::vrpn_nVidia_shield_USB(const char *name, vrpn_Connection *c)
-    : vrpn_nVidia_shield(d_filter = new vrpn_HidProductAcceptor(NVIDIA_VENDOR, NVIDIA_SHIELD_USB), name, c, NVIDIA_VENDOR, NVIDIA_SHIELD_USB)
+    : vrpn_nVidia_shield(new vrpn_HidProductAcceptor(NVIDIA_VENDOR, NVIDIA_SHIELD_USB), name, c, NVIDIA_VENDOR, NVIDIA_SHIELD_USB)
   , vrpn_Analog(name, c)
   , vrpn_Button_Filter(name, c)
 {


### PR DESCRIPTION
Removes reduntant (and strictly illegal) setting of member variable in not-yet-constructed parent object in several classes.  Explicitly type-casts variables in a print statement to the expected type.