### PR TITLE
allow pre-configuration of Trivisio Colibri tracker

### DIFF
--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -2211,18 +2211,20 @@
 ################################################################################
 # Trivisio ColibriAPI support.  This is an inertial tracker that gives orientation
 # information, no position (the tracker reports (0, 0, 0) for position).
-# Use automatically created current.conf as a template for configuration file.
 # If wireless Colibri do not answer, dongle scans for them automatically (20 seconds).
 # Wireless Colibri must be in scanning mode (button pushed for 2 seconds,
 # LED flashing fast).
 #
 # Arguments:
 #	char	name_of_this_device[]
-#	char	conf_file_name[] (xml-file with sensor network configuration
-#                               or * to use all connected devices.)
-#	int     Hz (Update rate)
-#	int     report_a_w (0 = orientation only, 1 = orientation + angular
-#			    velocity + acceleration)
+#	char	conf_file_name[] : xml-file with sensor network configuration.
+#               Use Colibri GUI to create the file. Settings must be set
+#               and saved in sensors' non-volatile memory using Colibri GUI.
+#               * - to use all connected devices. Default settings will be
+#               applied to sensors.
+#	int     Hz : Update rate.
+#	int     report_a_w : 0 = orientation only,
+#                        1 = orientation + angular velocity + acceleration.
 
 #vrpn_Tracker_Colibri Colibri * 100 0
 

--- a/vrpn_Tracker_Colibri.C
+++ b/vrpn_Tracker_Colibri.C
@@ -69,10 +69,12 @@ vrpn_Tracker_Colibri::vrpn_Tracker_Colibri(const char* name, vrpn_Connection* c,
             printf("%d: %s (FW %d.%.3d)\n", i, info.ID, info.FW_ver/1000, info.FW_ver%1000);
         }
 
-        result = TC_QuickConfig(nw, TCS_ORIENT | (report_a_w ? TCS_ACC|TCS_GYR : 0));
-        if (result != TCR_SUCCESS) {
-            printf("Colibri sensor error.\n");
-            break;
+        if (!path) { // No configuration file
+            result = TC_QuickConfig(nw, TCS_ORIENT | (report_a_w ? TCS_ACC|TCS_GYR : 0));
+            if (result != TCR_SUCCESS) {
+                printf("Colibri sensor error.\n");
+                break;
+            }
         }
 
         // Start the devices


### PR DESCRIPTION
Problem: on vrpn_server start default sensor configuration set by TC_QuickConfig replaces one
made in Trivisio Colibri GUI.
After this patch:
For automatic network configuration (* instead of file name in vrpn.cfg) default sensor configuration is applied.
If network configuration file is used - current sensor configuration is used.