### PR TITLE
libfreespace 0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -828,6 +828,7 @@ option_requires(VRPN_USE_FREESPACE
 	LIBFREESPACE_FOUND)
 
 if(VRPN_USE_FREESPACE)
+	configure_file(vrpn_Freespace.h.in "${CMAKE_CURRENT_BINARY_DIR}/vrpn_Freespace.h")
 	include_directories(${LIBFREESPACE_INCLUDE_DIRS})
 	list(APPEND SERVER_EXTRA_LIBS ${LIBFREESPACE_LIBRARIES})
 endif()

--- a/cmake/FindLibFreespace.cmake
+++ b/cmake/FindLibFreespace.cmake
@@ -85,8 +85,8 @@ file(WRITE "${_libfreespace_version_srcfile}"
 
 int main() {
 	std::string version = freespace_version();
-	std::replace(begin(version), end(version), '.', ';');
-	std::cout << version << std::endl;
+	std::replace(version.begin(), version.end(), '.', ';');
+	std::cout << version << std::flush;
 	return 0;
 }
 "
@@ -99,11 +99,11 @@ try_run(_libfreespace_run_result _libfreespace_compile_result
 	#COMPILE_OUTPUT_VARIABLE _libfreespace_compiler_output
 	RUN_OUTPUT_VARIABLE LIBFREESPACE_VERSION)
 
-if(LIBFREESPACE_VERSION)
-	list(GET LIBFREESPACE_VERSION 0 LIBFREESPACE_MAJOR_VERSION)
-	list(GET LIBFREESPACE_VERSION 1 LIBFREESPACE_MINOR_VERSION)
-	list(GET LIBFREESPACE_VERSION 2 LIBFREESPACE_PATCH_VERSION)
-endif()
+#message(STATUS "libfreespace compiler output = ${_libfreespace_compiler_output}")
+list(APPEND LIBFREESPACE_VERSION 0 0 0) # in case one or more version segments are unused
+list(GET LIBFREESPACE_VERSION 0 LIBFREESPACE_MAJOR_VERSION)
+list(GET LIBFREESPACE_VERSION 1 LIBFREESPACE_MINOR_VERSION)
+list(GET LIBFREESPACE_VERSION 2 LIBFREESPACE_PATCH_VERSION)
 
 mark_as_advanced(LIBFREESPACE_INCLUDE_DIR
 	LIBFREESPACE_LIBRARY)

--- a/cmake/FindLibFreespace.cmake
+++ b/cmake/FindLibFreespace.cmake
@@ -74,5 +74,37 @@ if(LIBFREESPACE_FOUND)
 	mark_as_advanced(LIBFREESPACE_ROOT_DIR)
 endif()
 
+# Get the version number of the Freespace library
+set(_libfreespace_version_srcfile "${CMAKE_BINARY_DIR}/freespace_version.cpp")
+file(WRITE "${_libfreespace_version_srcfile}"
+"
+#include <freespace/freespace.h>
+#include <algorithm>
+#include <iostream>
+#include <string>
+
+int main() {
+	std::string version = freespace_version();
+	std::replace(begin(version), end(version), '.', ';');
+	std::cout << version << std::endl;
+	return 0;
+}
+"
+)
+try_run(_libfreespace_run_result _libfreespace_compile_result
+	${CMAKE_BINARY_DIR}
+	${_libfreespace_version_srcfile}
+	CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${LIBFREESPACE_INCLUDE_DIRS}"
+	LINK_LIBRARIES ${LIBFREESPACE_LIBRARIES}
+	#COMPILE_OUTPUT_VARIABLE _libfreespace_compiler_output
+	RUN_OUTPUT_VARIABLE LIBFREESPACE_VERSION)
+
+if(LIBFREESPACE_VERSION)
+	list(GET LIBFREESPACE_VERSION 0 LIBFREESPACE_MAJOR_VERSION)
+	list(GET LIBFREESPACE_VERSION 1 LIBFREESPACE_MINOR_VERSION)
+	list(GET LIBFREESPACE_VERSION 2 LIBFREESPACE_PATCH_VERSION)
+endif()
+
 mark_as_advanced(LIBFREESPACE_INCLUDE_DIR
 	LIBFREESPACE_LIBRARY)
+

--- a/vrpn_Freespace.C
+++ b/vrpn_Freespace.C
@@ -1,19 +1,23 @@
 #include "vrpn_Freespace.h"
+
 #ifdef VRPN_USE_FREESPACE
+
 #include "quat.h"
+
 #include <freespace/freespace_codecs.h>
+#include <freespace/freespace_util.h>
+
 #include <cstring>
-static const q_type gs_qIdent = Q_ID_QUAT;
 
-// We've not yet initialized the FreeSpace library.
-bool vrpn_Freespace::_freespace_initialized = false;
+static q_type gs_qIdent = Q_ID_QUAT;
 
-// libfreespace provides linear acceleration values in (mm/(s^2))^-3 
+// some libfreespace devices provide linear acceleration values in (mm/(s^2))^-3 
 // VRPN wants these in meters/(s^2)
 static vrpn_float64 convertFreespaceLinearAccelation(int16_t mmpss) {
-	return mmpss / ((vrpn_float64) 1000);
+    return mmpss / ((vrpn_float64) 1000);
 }
-// freespace reports in milliradians per second, so need to convert
+
+// some freespace devices report in milliradians per second, so need to convert
 // to meters per second...
 // The radius to use is a bit arbitrary, and would depend on 
 // what exactly this device is 'attached' to.  Additionally, this may 
@@ -21,35 +25,46 @@ static vrpn_float64 convertFreespaceLinearAccelation(int16_t mmpss) {
 // matter since the device may be representing a larger/smaller object in
 // the virtual world.
 static vrpn_float64 convertFreespaceAngularVelocity(int16_t mrps, double radius) {
-	return mrps * radius / ((vrpn_float64) 1000);
+    return mrps * radius / ((vrpn_float64) 1000);
 }
+
+// some freespace devices report in radians per second 
+static vrpn_float64 convertFreespaceAngularVelocityRadPerSecond(int16_t mrps, double radius) {
+    return mrps * radius;
+}
+
+
 #define MILLIS_TO_SECONDS(x) (x / ((vrpn_float64) 1000000))
 
+#define SCOOP_PID 0xC0B3
+#define FSM6_PID 0xC080
+#define FSM9_PID 0xC0E0
 
 vrpn_Freespace::vrpn_Freespace(FreespaceDeviceId freespaceId,
         struct FreespaceDeviceInfo* deviceInfo,
-        const char *name, vrpn_Connection *conn):
-        vrpn_Tracker_Server(name, conn),
-        vrpn_Button_Filter(name, conn),
-        vrpn_Dial(name, conn)
+        const char *name, vrpn_Connection *conn) :
+    vrpn_Tracker_Server(name, conn),
+    vrpn_Button_Filter(name, conn),
+    vrpn_Dial(name, conn),
+    _freespaceDevice(freespaceId)
 {
-	memcpy(&_deviceInfo, deviceInfo, sizeof(_deviceInfo));
-	// 5 buttons + a scroll wheel
-	vrpn_Button::num_buttons = 5;
-	vrpn_Dial::num_dials = 1;
-	memset(&_lastBodyFrameTime, 0, sizeof(_lastBodyFrameTime));
-	_timestamp.tv_sec = 0;
+    memcpy(&_deviceInfo, deviceInfo, sizeof(_deviceInfo));
+    // 5 buttons + a scroll wheel
+    vrpn_Button::num_buttons = 5;
+    vrpn_Dial::num_dials = 1;
+    memset(&_lastBodyFrameTime, 0, sizeof(_lastBodyFrameTime));
+    _timestamp.tv_sec = 0;
 }
 
 void vrpn_Freespace::freespaceInit() {
-	if (!_freespace_initialized) {
-		_freespace_initialized = true;
-		int rc = freespace_init();
-		if (rc != FREESPACE_SUCCESS) {
-			fprintf(stderr, "vrpn_Freespace::freespaceInit: failed to init freespace lib. rc=%d\n", rc);
-			_freespace_initialized = false;
-		}
-	}
+    static bool freespaceInit = false;
+    if (!freespaceInit) {
+        freespaceInit = true;
+        int rc = freespace_init();
+        if (rc != FREESPACE_SUCCESS) {
+            fprintf(stderr, "vrpn_Freespace::freespaceInit: failed to init freespace lib. rc=%d\n", rc);
+        }
+    }
 }
 
 void vrpn_Freespace::deviceSetConfiguration(bool send_body_frames, bool send_user_frames) {
@@ -59,10 +74,64 @@ void vrpn_Freespace::deviceSetConfiguration(bool send_body_frames, bool send_use
 
 void vrpn_Freespace::deviceConfigure() {
     int rc = 0;
+    int deviceType = 0;
 
     // Send the data mode request
     struct freespace_message message;
     memset(&message, 0, sizeof(message));
+
+#if FREESPACE_VERSION_GREATER_THAN(0,7,0)
+    switch (_deviceInfo.product) {
+        case FSM6_PID:
+            message.messageType = FREESPACE_MESSAGE_DATAMODECONTROLV2REQUEST;
+            message.dataModeControlV2Request.packetSelect = 8; // MotionEngine Output
+            message.dataModeControlV2Request.mode = 4; // Full Motion On
+            message.dataModeControlV2Request.formatSelect = 0; // Format 0
+            if (_sendBodyFrames) {
+                message.dataModeControlV2Request.ff1 = 1; // Enable Linear Acceleration
+                message.dataModeControlV2Request.ff3 = 1; // Enable Angular Velocity
+                message.dataModeControlV2Request.ff0 = 1; // Enable cursor and buttons
+            }
+            if (_sendUserFrames) {
+                message.dataModeControlV2Request.ff6 = 1; // Enable Angular Position
+                message.dataModeControlV2Request.ff0 = 1; // Enable cursor and buttons
+            }
+            break;
+        case FSM9_PID:
+            message.messageType = FREESPACE_MESSAGE_DATAMODECONTROLV2REQUEST;
+            message.dataModeControlV2Request.packetSelect = 8; // MotionEngine Output
+            message.dataModeControlV2Request.mode = 4; // Full Motion On
+            message.dataModeControlV2Request.formatSelect = 0; // Format 0
+            if (_sendBodyFrames) {
+                message.dataModeControlV2Request.ff1 = 1; // Enable Linear Acceleration
+                message.dataModeControlV2Request.ff3 = 1; // Enable Angular Velocity
+                message.dataModeControlV2Request.ff0 = 1; // Enable cursor and buttons
+            }
+            if (_sendUserFrames) {
+                message.dataModeControlV2Request.ff6 = 1; // Enable Angular Position
+                message.dataModeControlV2Request.ff0 = 1; // Enable cursor and buttons
+            }
+            break;
+        case SCOOP_PID:
+            //Send V2 request.
+            message.messageType = FREESPACE_MESSAGE_DATAMODECONTROLV2REQUEST;
+            message.dataModeControlV2Request.packetSelect = 4;
+            if (_sendBodyFrames) {
+                if (_sendUserFrames) {
+                    message.dataModeControlV2Request.packetSelect = 4; // BodyUserFrame Message
+                } else {
+                    message.dataModeControlV2Request.packetSelect = 2; // BodyFrame Message
+                }
+            } else if (_sendUserFrames) {
+                message.dataModeControlV2Request.packetSelect = 3; // UserFrame Message
+            }
+            message.dataModeControlV2Request.mode = 4;
+            break;
+        default:
+            printf("Unsupported Freespace device\n");
+            break;
+    }
+#else
     if (_deviceInfo.hVer == 1) {
         message.messageType = FREESPACE_MESSAGE_DATAMOTIONCONTROL;
         struct freespace_DataMotionControl * req;
@@ -82,6 +151,7 @@ void vrpn_Freespace::deviceConfigure() {
         req->enableMouseMovement = 0;
         req->disableFreespace = 0;
     }
+#endif
 
     rc = freespace_sendMessage(_freespaceDevice, &message);
     if (rc != FREESPACE_SUCCESS) {
@@ -95,6 +165,29 @@ void vrpn_Freespace::deviceUnconfigure() {
     // Send the data mode request
     struct freespace_message message;
     memset(&message, 0, sizeof(message));
+
+#if FREESPACE_VERSION_GREATER_THAN(0,7,0)
+    switch(_deviceInfo.product) {
+        case SCOOP_PID:
+            message.messageType = FREESPACE_MESSAGE_DATAMODECONTROLV2REQUEST;
+            message.dataModeControlV2Request.packetSelect = 1; // Mouse mode
+            message.dataModeControlV2Request.mode = 0; // Full motion
+            break;
+        case FSM6_PID:
+            message.messageType = FREESPACE_MESSAGE_DATAMODECONTROLV2REQUEST;
+            message.dataModeControlV2Request.packetSelect = 1; // Mouse mode
+            message.dataModeControlV2Request.mode = 0; // Full motion
+            break;
+        case FSM9_PID:
+            message.messageType = FREESPACE_MESSAGE_DATAMODECONTROLV2REQUEST;
+            message.dataModeControlV2Request.packetSelect = 0; // None
+            message.dataModeControlV2Request.mode = 1; // Sleep
+            break;
+        default:
+            printf("Unsupported Freespace device\n");
+            break;
+    } 
+#else
     if (_deviceInfo.hVer == 1) {
         message.messageType = FREESPACE_MESSAGE_DATAMOTIONCONTROL;
         struct freespace_DataMotionControl * req;
@@ -114,6 +207,7 @@ void vrpn_Freespace::deviceUnconfigure() {
         req->enableMouseMovement = 1;
         req->disableFreespace = 0;
     }
+#endif
 
     rc = freespace_sendMessage(_freespaceDevice, &message);
     if (rc != FREESPACE_SUCCESS) {
@@ -149,6 +243,11 @@ vrpn_Freespace* vrpn_Freespace::create(const char *name, vrpn_Connection *conn,
     if (rc != FREESPACE_SUCCESS) {
         return NULL;
     }
+
+#if FREESPACE_VERSION_GREATER_THAN(0,7,0)
+    printf("\nFreespace Device Info:\n----------------------\nDevice = %s\nVendor ID = 0x%x (%d) \nProduct ID = 0x%x (%d)\n\n", deviceInfo.name, deviceInfo.vendor, deviceInfo.vendor, deviceInfo.product, deviceInfo.product);
+#endif
+
     rc = freespace_flush(freespaceId);
     if (rc != FREESPACE_SUCCESS) {
         fprintf(stderr, "vrpn_Freespace::create: Error flushing device: %d\n", rc);
@@ -163,7 +262,7 @@ vrpn_Freespace* vrpn_Freespace::create(const char *name, vrpn_Connection *conn,
 
 void vrpn_Freespace::mainloop(void) 
 {
-	server_mainloop();
+    server_mainloop();
     struct freespace_message s;
 
     /*
@@ -179,123 +278,283 @@ void vrpn_Freespace::mainloop(void)
         deviceConfigure();
     }
 
-	// Do not block, read as many messages as 
+    // Do not block, read as many messages as 
     while (FREESPACE_SUCCESS == freespace_readMessage(_freespaceDevice, &s, 0)) {
-	    switch(s.messageType) {
-		    case FREESPACE_MESSAGE_LINKSTATUS:
-			    handleLinkStatus(s.linkStatus);
-			    break;
-		    case FREESPACE_MESSAGE_BODYFRAME:
-			    handleBodyFrame(s.bodyFrame);
-			    break;
-		    case FREESPACE_MESSAGE_USERFRAME:
-			    handleUserFrame(s.userFrame);
-			    break;
+        switch(s.messageType) {
+            case FREESPACE_MESSAGE_LINKSTATUS:
+                handleLinkStatus(s.linkStatus);
+                break;
+            case FREESPACE_MESSAGE_BODYFRAME:
+                handleBodyFrame(s.bodyFrame);
+                break;
+            case FREESPACE_MESSAGE_USERFRAME:
+                handleUserFrame(s.userFrame);
+                break;
+#if FREESPACE_VERSION_GREATER_THAN(0,7,0)
+            case FREESPACE_MESSAGE_BODYUSERFRAME:
+                handleBodyUserFrame(s.bodyUserFrame);
+                break;
+#endif
             case FREESPACE_MESSAGE_ALWAYSONRESPONSE:
                 break;
             case FREESPACE_MESSAGE_DATAMODERESPONSE:
                 break;
-		    default:
+#if FREESPACE_VERSION_GREATER_THAN(0,7,0)
+            case FREESPACE_MESSAGE_PRODUCTIDRESPONSE:
+                break;
+            case FREESPACE_MESSAGE_DATAMODECONTROLV2RESPONSE:
+                break;
+            case FREESPACE_MESSAGE_MOTIONENGINEOUTPUT:
+                handleMotionEngineOutput(s.motionEngineOutput);
+                break;
+#endif
+            default:
                 send_text_message("Received an unhandled message from freespace device", timestamp, vrpn_TEXT_WARNING);
-			    break;
-	    }
+                break;
+        }
     }
 }
 vrpn_Freespace::~vrpn_Freespace(void)
 {
-	// as part of cleanup, disable user and body frame messages, and
-	// put back to just mouse movement.
-	int rc = freespace_flush(_freespaceDevice);
+    // as part of cleanup, disable user and body frame messages, and
+    // put back to just mouse movement.
+    int rc = freespace_flush(_freespaceDevice);
     if (rc != FREESPACE_SUCCESS) {
         printf("freespaceInputThread: Error flushing device: %d\n", rc);
     }
 
     deviceUnconfigure();
-	freespace_closeDevice(_freespaceDevice);
+    freespace_closeDevice(_freespaceDevice);
 }
 
 void vrpn_Freespace::handleBodyFrame(const struct freespace_BodyFrame& body) {
-			vrpn_gettimeofday(&(vrpn_Tracker::timestamp), NULL);
-	vrpn_float64 now  = vrpn_Tracker::timestamp.tv_sec + MILLIS_TO_SECONDS(vrpn_Tracker::timestamp.tv_usec);
-	vrpn_float64 delta = now - _lastBodyFrameTime;
-	_lastBodyFrameTime = now;
+    vrpn_gettimeofday(&(vrpn_Tracker::timestamp), NULL);
+    vrpn_float64 now  = vrpn_Tracker::timestamp.tv_sec + MILLIS_TO_SECONDS(vrpn_Tracker::timestamp.tv_usec);
+    vrpn_float64 delta = now - _lastBodyFrameTime;
+    _lastBodyFrameTime = now;
 
     vrpn_Tracker::acc[0] = convertFreespaceLinearAccelation(body.linearAccelX);
-	vrpn_Tracker::acc[1] = convertFreespaceLinearAccelation(body.linearAccelY);
-	vrpn_Tracker::acc[2] = convertFreespaceLinearAccelation(body.linearAccelZ);
-	q_copy(vrpn_Tracker::acc_quat, gs_qIdent);
-	vrpn_Tracker::acc_quat_dt = delta;
+    vrpn_Tracker::acc[1] = convertFreespaceLinearAccelation(body.linearAccelY);
+    vrpn_Tracker::acc[2] = convertFreespaceLinearAccelation(body.linearAccelZ);
+    q_copy(vrpn_Tracker::acc_quat, gs_qIdent);
+    vrpn_Tracker::acc_quat_dt = delta;
     vrpn_Tracker_Server::report_pose_acceleration(0, vrpn_Tracker::timestamp,
-        vrpn_Tracker::acc, vrpn_Tracker::acc_quat, delta);
+            vrpn_Tracker::acc, vrpn_Tracker::acc_quat, delta);
 
-	vrpn_Tracker::vel[0] = convertFreespaceAngularVelocity(body.angularVelX, 1);
-	vrpn_Tracker::vel[1] = convertFreespaceAngularVelocity(body.angularVelY, 1);
-	vrpn_Tracker::vel[2] = convertFreespaceAngularVelocity(body.angularVelZ, 1);
-	q_copy(vrpn_Tracker::vel_quat, gs_qIdent);
-	vrpn_Tracker::vel_quat_dt = delta;
+    vrpn_Tracker::vel[0] = convertFreespaceAngularVelocity(body.angularVelX, 1);
+    vrpn_Tracker::vel[1] = convertFreespaceAngularVelocity(body.angularVelY, 1);
+    vrpn_Tracker::vel[2] = convertFreespaceAngularVelocity(body.angularVelZ, 1);
+    q_copy(vrpn_Tracker::vel_quat, gs_qIdent);
+    vrpn_Tracker::vel_quat_dt = delta;
     vrpn_Tracker_Server::report_pose_velocity(0, vrpn_Tracker::timestamp,
-        vrpn_Tracker::vel, vrpn_Tracker::vel_quat, vrpn_Tracker::vel_quat_dt);
+            vrpn_Tracker::vel, vrpn_Tracker::vel_quat, vrpn_Tracker::vel_quat_dt);
 
     vrpn_Button::buttons[0] = body.button1;
-	vrpn_Button::buttons[1] = body.button2;
-	vrpn_Button::buttons[2] = body.button3;
-	vrpn_Button::buttons[3] = body.button4;
-	vrpn_Button::buttons[4] = body.button5;
-	
-	vrpn_Button::timestamp = vrpn_Tracker::timestamp;
-	vrpn_Button::report_changes();
+    vrpn_Button::buttons[1] = body.button2;
+    vrpn_Button::buttons[2] = body.button3;
+    vrpn_Button::buttons[3] = body.button4;
+    vrpn_Button::buttons[4] = body.button5;
 
-	// this is totally arbitrary
-	// I'm not sure how exactly the 'deltaWheel' should be interpreted, but it seems
-	// like it would be the number of 'clicks' while turning the scroll wheel...
-	// vrpn was this as a 'fraction of a revolution' so I would assume that a return of 1 means
-	// the dial was spun 360 degrees.  I'm going to pretend it takes 16 clicks to make a full
-	// revolution....'
-	// this values should probably set in a configuration file.
-	vrpn_Dial::dials[0] = body.deltaWheel / (vrpn_float64) 16;
-	vrpn_Dial::timestamp = vrpn_Tracker::timestamp;
-	vrpn_Dial::report_changes();
+    vrpn_Button::timestamp = vrpn_Tracker::timestamp;
+    vrpn_Button::report_changes();
+
+    // this is totally arbitrary
+    // I'm not sure how exactly the 'deltaWheel' should be interpreted, but it seems
+    // like it would be the number of 'clicks' while turning the scroll wheel...
+    // vrpn was this as a 'fraction of a revolution' so I would assume that a return of 1 means
+    // the dial was spun 360 degrees.  I'm going to pretend it takes 16 clicks to make a full
+    // revolution....'
+    // this values should probably set in a configuration file.
+    vrpn_Dial::dials[0] = body.deltaWheel / (vrpn_float64) 16;
+    vrpn_Dial::timestamp = vrpn_Tracker::timestamp;
+    vrpn_Dial::report_changes();
 }
 
 void vrpn_Freespace::handleUserFrame(const struct freespace_UserFrame& user) {
-			vrpn_gettimeofday(&(vrpn_Tracker::timestamp), NULL);
+    vrpn_gettimeofday(&(vrpn_Tracker::timestamp), NULL);
 
     // Translate the Freespace linear position into VRPN linear position.
-	vrpn_Tracker::pos[0] = user.linearPosY;
-	vrpn_Tracker::pos[1] = user.linearPosZ;
-	vrpn_Tracker::pos[2] = user.linearPosX;
-		
+    vrpn_Tracker::pos[0] = user.linearPosY;
+    vrpn_Tracker::pos[1] = user.linearPosZ;
+    vrpn_Tracker::pos[2] = user.linearPosX;
+
     // Transfer the Freespace coordinate system angular position quanternion
     // into the VRPN coordinate system.  
-	vrpn_Tracker::d_quat[Q_W] = user.angularPosA;
-	vrpn_Tracker::d_quat[Q_X] = user.angularPosC;
-	vrpn_Tracker::d_quat[Q_Y] = -user.angularPosD;
-	vrpn_Tracker::d_quat[Q_Z] = user.angularPosB;
+    vrpn_Tracker::d_quat[Q_W] = user.angularPosA;
+    vrpn_Tracker::d_quat[Q_X] = user.angularPosC;
+    vrpn_Tracker::d_quat[Q_Y] = -user.angularPosD;
+    vrpn_Tracker::d_quat[Q_Z] = user.angularPosB;
     q_normalize(vrpn_Tracker::d_quat, vrpn_Tracker::d_quat);
 
     vrpn_Tracker_Server::report_pose(0, vrpn_Tracker::timestamp, vrpn_Tracker::pos, vrpn_Tracker::d_quat);
 
-	vrpn_Button::buttons[0] = user.button1;
-	vrpn_Button::buttons[1] = user.button2;
-	vrpn_Button::buttons[2] = user.button3;
-	vrpn_Button::buttons[3] = user.button4;
-	vrpn_Button::buttons[4] = user.button5;
-	
-	vrpn_Button::timestamp = vrpn_Tracker::timestamp;
-	vrpn_Button::report_changes();
+    vrpn_Button::buttons[0] = user.button1;
+    vrpn_Button::buttons[1] = user.button2;
+    vrpn_Button::buttons[2] = user.button3;
+    vrpn_Button::buttons[3] = user.button4;
+    vrpn_Button::buttons[4] = user.button5;
 
-	// this is totally arbitrary
-	// I'm not sure how exactly the 'deltaWheel' should be interpreted, but it seems
-	// like it would be the number of 'clicks' while turning the scroll wheel...
-	// vrpn was this as a 'fraction of a revolution' so I would assume that a return of 1 means
-	// the dial was spun 360 degrees.  I'm going to pretend it takes 16 clicks to make a full
-	// revolution....'
-	// this values should probably set in a configuration file.
-	vrpn_Dial::dials[0] = user.deltaWheel / (vrpn_float64) 16;
-	vrpn_Dial::timestamp = vrpn_Tracker::timestamp;
-	vrpn_Dial::report_changes();
+    vrpn_Button::timestamp = vrpn_Tracker::timestamp;
+    vrpn_Button::report_changes();
+
+    // this is totally arbitrary
+    // I'm not sure how exactly the 'deltaWheel' should be interpreted, but it seems
+    // like it would be the number of 'clicks' while turning the scroll wheel...
+    // vrpn was this as a 'fraction of a revolution' so I would assume that a return of 1 means
+    // the dial was spun 360 degrees.  I'm going to pretend it takes 16 clicks to make a full
+    // revolution....'
+    // this values should probably set in a configuration file.
+    vrpn_Dial::dials[0] = user.deltaWheel / (vrpn_float64) 16;
+    vrpn_Dial::timestamp = vrpn_Tracker::timestamp;
+    vrpn_Dial::report_changes();
 }
+
+#if FREESPACE_VERSION_GREATER_THAN(0,7,0)
+void vrpn_Freespace::handleBodyUserFrame(const struct freespace_BodyUserFrame& bodyUser) 
+{
+    vrpn_gettimeofday(&(vrpn_Tracker::timestamp), NULL);
+
+    vrpn_float64 now  = vrpn_Tracker::timestamp.tv_sec + MILLIS_TO_SECONDS(vrpn_Tracker::timestamp.tv_usec);
+    vrpn_float64 delta = now - _lastBodyFrameTime;
+    _lastBodyFrameTime = now;
+
+    // Translate the Freespace lienar position into VRPN linear position.
+    // NOTE:  Linear position is not supported by most Freespace devices so this could be garbage.
+    vrpn_Tracker::pos[0] = bodyUser.linearPosX;
+    vrpn_Tracker::pos[1] = bodyUser.linearPosY;
+    vrpn_Tracker::pos[2] = bodyUser.linearPosZ;
+
+    // Transfer the Freespace coordinate system angular position quaternion
+    // into the VRPN coordinate system.
+    vrpn_Tracker::d_quat[Q_W] = bodyUser.angularPosA;
+    vrpn_Tracker::d_quat[Q_X] = bodyUser.angularPosC;
+    vrpn_Tracker::d_quat[Q_Y] = -bodyUser.angularPosD;
+    vrpn_Tracker::d_quat[Q_Z] = bodyUser.angularPosB;
+    q_normalize(vrpn_Tracker::d_quat, vrpn_Tracker::d_quat);
+
+    vrpn_Tracker::acc[0] = convertFreespaceLinearAccelation(bodyUser.linearAccelX);
+    vrpn_Tracker::acc[1] = convertFreespaceLinearAccelation(bodyUser.linearAccelY);
+    vrpn_Tracker::acc[2] = convertFreespaceLinearAccelation(bodyUser.linearAccelZ);
+    q_copy(vrpn_Tracker::acc_quat, gs_qIdent);
+    vrpn_Tracker::acc_quat_dt = delta;
+    vrpn_Tracker_Server::report_pose_acceleration(0, vrpn_Tracker::timestamp,
+            vrpn_Tracker::acc, vrpn_Tracker::acc_quat, delta);
+
+    vrpn_Tracker::vel[0] = convertFreespaceAngularVelocity(bodyUser.angularVelX, 1);
+    vrpn_Tracker::vel[1] = convertFreespaceAngularVelocity(bodyUser.angularVelY, 1);
+    vrpn_Tracker::vel[2] = convertFreespaceAngularVelocity(bodyUser.angularVelZ, 1);
+    q_copy(vrpn_Tracker::vel_quat, gs_qIdent);
+    vrpn_Tracker::vel_quat_dt = delta;
+    vrpn_Tracker_Server::report_pose_velocity(0, vrpn_Tracker::timestamp,
+            vrpn_Tracker::vel, vrpn_Tracker::vel_quat, vrpn_Tracker::vel_quat_dt);
+
+    vrpn_Tracker_Server::report_pose(0, vrpn_Tracker::timestamp, vrpn_Tracker::pos, vrpn_Tracker::d_quat);
+
+    vrpn_Button::buttons[0] = bodyUser.button1;
+    vrpn_Button::buttons[1] = bodyUser.button2;
+    vrpn_Button::buttons[2] = bodyUser.button3;
+    vrpn_Button::buttons[3] = bodyUser.button4;
+    vrpn_Button::buttons[4] = bodyUser.button5;
+
+    vrpn_Button::timestamp = vrpn_Tracker::timestamp;
+    vrpn_Button::report_changes();
+
+    // this is totally arbitrary
+    // I'm not sure how exactly the 'deltaWheel' should be interpreted, but it seems
+    // like it would be the number of 'clicks' while turning the scroll wheel...
+    // vrpn was this as a 'fraction of a revolution' so I would assume that a return of 1 means
+    // the dial was spun 360 degrees.  I'm going to pretend it takes 16 clicks to make a full
+    // revolution....'
+    // this values should probably set in a configuration file.
+    vrpn_Dial::dials[0] = bodyUser.deltaWheel / (vrpn_float64) 16;
+    vrpn_Dial::timestamp = vrpn_Tracker::timestamp;
+    vrpn_Dial::report_changes();
+
+}
+
+void vrpn_Freespace::handleMotionEngineOutput(const struct freespace_MotionEngineOutput& s) {
+    vrpn_gettimeofday(&(vrpn_Tracker::timestamp), NULL);
+
+    vrpn_float64 now  = vrpn_Tracker::timestamp.tv_sec + MILLIS_TO_SECONDS(vrpn_Tracker::timestamp.tv_usec);
+    vrpn_float64 delta = now - _lastBodyFrameTime;
+    _lastBodyFrameTime = now;
+
+    struct MultiAxisSensor angPos;
+    struct MultiAxisSensor linAcc;
+    struct MultiAxisSensor rotVel;
+
+    if (_sendUserFrames) {
+        // Translate the Freespace linear position into VRPN linear position.
+        vrpn_Tracker::pos[0] = 0; // Linear position unsupported with Freespace devices
+        vrpn_Tracker::pos[1] = 0;
+        vrpn_Tracker::pos[2] = 0;
+
+        // Transfer the Freespace coordinate system angular position quanternion
+        // into the VRPN coordinate system.  
+
+        freespace_util_getAngPos(&s, &angPos);
+
+        vrpn_Tracker::d_quat[Q_W] = angPos.w;
+        vrpn_Tracker::d_quat[Q_X] = angPos.y;
+        vrpn_Tracker::d_quat[Q_Y] = -angPos.z;
+        vrpn_Tracker::d_quat[Q_Z] = angPos.x;
+        q_normalize(vrpn_Tracker::d_quat, vrpn_Tracker::d_quat);
+
+        vrpn_Tracker_Server::report_pose(0, vrpn_Tracker::timestamp, vrpn_Tracker::pos, vrpn_Tracker::d_quat);
+    }
+
+    if (_sendBodyFrames) {
+        // Transfer the linear acceleration values
+
+        freespace_util_getAcceleration(&s, &linAcc);
+
+        vrpn_Tracker::acc[0] = linAcc.x;
+        vrpn_Tracker::acc[1] = linAcc.y;
+        vrpn_Tracker::acc[2] = linAcc.z;
+
+        q_copy(vrpn_Tracker::acc_quat, gs_qIdent);
+        vrpn_Tracker::acc_quat_dt = delta;
+        vrpn_Tracker_Server::report_pose_acceleration(0, vrpn_Tracker::timestamp,
+                vrpn_Tracker::acc, vrpn_Tracker::acc_quat, delta);
+
+        // Transfer the angular velocity values
+
+        freespace_util_getAngularVelocity(&s, &rotVel);
+
+        vrpn_Tracker::vel[0] = rotVel.x;
+        vrpn_Tracker::vel[1] = rotVel.y;
+        vrpn_Tracker::vel[2] = rotVel.z;
+        q_copy(vrpn_Tracker::vel_quat, gs_qIdent);
+        vrpn_Tracker::vel_quat_dt = delta;
+        vrpn_Tracker_Server::report_pose_velocity(0, vrpn_Tracker::timestamp,
+                vrpn_Tracker::vel, vrpn_Tracker::vel_quat, vrpn_Tracker::vel_quat_dt);
+    }
+
+    vrpn_Button::buttons[0] = (s.meData[0] >> 0 & 0x01);
+    vrpn_Button::buttons[1] = (s.meData[0] >> 1 & 0x01);
+    vrpn_Button::buttons[2] = (s.meData[0] >> 2 & 0x01);
+    vrpn_Button::buttons[3] = (s.meData[0] >> 3 & 0x01);
+    vrpn_Button::buttons[4] = (s.meData[0] >> 4 & 0x01);
+
+    vrpn_Button::timestamp = vrpn_Tracker::timestamp;
+    vrpn_Button::report_changes();
+
+    // this is totally arbitrary
+    // I'm not sure how exactly the 'deltaWheel' should be interpreted, but it seems
+    // like it would be the number of 'clicks' while turning the scroll wheel...
+    // vrpn was this as a 'fraction of a revolution' so I would assume that a return of 1 means
+    // the dial was spun 360 degrees.  I'm going to pretend it takes 16 clicks to make a full
+    // revolution....'
+    // this values should probably set in a configuration file.
+    vrpn_Dial::dials[0] = s.meData[5] / (vrpn_float64) 16;
+    vrpn_Dial::timestamp = vrpn_Tracker::timestamp;
+    vrpn_Dial::report_changes();
+}
+#endif
+
 void vrpn_Freespace::handleLinkStatus(const struct freespace_LinkStatus& l) {
-	// Could be used to send messages when the loop is powered off/unavailable.
+    // Could be used to send messages when the loop is powered off/unavailable.
 }
-#endif //VRPN_USE_FREESPACE
+
+#endif // VRPN_USE_FREESPACE
+

--- a/vrpn_Freespace.C
+++ b/vrpn_Freespace.C
@@ -5,7 +5,9 @@
 #include "quat.h"
 
 #include <freespace/freespace_codecs.h>
+#if FREESPACE_VERSION_GREATER_THAN(0,7,0)
 #include <freespace/freespace_util.h>
+#endif
 
 #include <cstring>
 

--- a/vrpn_Freespace.h.in
+++ b/vrpn_Freespace.h.in
@@ -29,6 +29,65 @@
 #include "vrpn_Dial.h"
 #include "vrpn_Tracker.h"
 
+/**
+ * The following values are filled in by CMake.
+ */
+//@{
+#define LIBFREESPACE_MAJOR_VERSION @LIBFREESPACE_MAJOR_VERSION@
+#define LIBFREESPACE_MINOR_VERSION @LIBFREESPACE_MINOR_VERSION@
+#define LIBFREESPACE_PATCH_VERSION @LIBFREESPACE_PATCH_VERSION@
+//@}
+
+/**
+ * Helper function that takes three components of a version number (each
+ * component must be a positive integer in the range [0, 99]) and generates a
+ * single integer value in its place. For example, FREESPACE_MAKE_VERSION(2, 3, 4)
+ * would return 20304.
+ */
+#define FREESPACE_MAKE_VERSION(MAJOR, MINOR, PATCH) \
+    (MAJOR   *   10000 + \
+     MINOR   *     100 + \
+     PATCH)
+
+/**
+ * Defines the Oculus SDK version as a single integer.
+ */
+#define FREESPACE_VERSION \
+    FREESPACE_MAKE_VERSION(LIBFREESPACE_MAJOR_VERSION, \
+                           LIBFREESPACE_MINOR_VERSION, \
+                           LIBFREESPACE_PATCH_VERSION)
+
+/**
+ * Convenience macros that can be used to specify a required version of the
+ * Freespace library.
+ *
+ * <code>
+ * #if FREESPACE_MIN_VERSION_REQUIRED(0, 7, 0)
+ *    // your code here
+ * #endif
+ * </code>
+ */
+//@{
+#define FREESPACE_MIN_VERSION_REQUIRED(MAJOR, MINOR, PATCH) \
+    (FREESPACE_MAKE_VERSION(MAJOR, MINOR, PATCH) >= FREESPACE_VERSION)
+
+#define FREESPACE_VERSION_LESS_THAN(MAJOR, MINOR, PATCH) \
+    (FREESPACE_VERSION < FREESPACE_MAKE_VERSION(MAJOR, MINOR, PATCH))
+
+#define FREESPACE_VERSION_LESS_OR_EQUAL(MAJOR, MINOR, PATCH) \
+    (FREESPACE_VERSION <= FREESPACE_MAKE_VERSION(MAJOR, MINOR, PATCH))
+
+#define FREESPACE_VERSION_GREATER_THAN(MAJOR, MINOR, PATCH) \
+    (FREESPACE_VERSION > FREESPACE_MAKE_VERSION(MAJOR, MINOR, PATCH))
+
+#define FREESPACE_VERSION_GREATER_OR_EQUAL(MAJOR, MINOR, PATCH) \
+    (FREESPACE_VERSION >= FREESPACE_MAKE_VERSION(MAJOR, MINOR, PATCH))
+
+#define FREESPACE_VERSION_EQUAL(MAJOR, MINOR, PATCH) \
+    (FREESPACE_VERSION == FREESPACE_MAKE_VERSION(MAJOR, MINOR, PATCH))
+//@}
+
+
 
 class VRPN_API vrpn_Freespace :
 	public vrpn_Tracker_Server,   // for the positional data
@@ -54,7 +113,7 @@ public:
 
 	static vrpn_Freespace* create(const char *name, 
 								  vrpn_Connection *conn, 
-				                  int device_index = 0,
+								  int device_index = 0,
 								  bool send_body_frames = false,
 								  bool send_user_frames = true);
 	virtual ~vrpn_Freespace(void);
@@ -66,7 +125,6 @@ public:
 	virtual void mainloop(void);
 
 private:
-	static bool _freespace_initialized;
 	static void freespaceInit();
 	/**
 	 * private constructor since opening of the device can fail.
@@ -79,6 +137,10 @@ private:
 	void handleUserFrame(const struct freespace_UserFrame&);
 	void handleBodyFrame(const struct freespace_BodyFrame&);
 	void handleLinkStatus(const struct freespace_LinkStatus&);
+#if FREESPACE_VERSION_GREATER_THAN(0,7,0)
+	void handleBodyUserFrame(const struct freespace_BodyUserFrame&);
+	void handleMotionEngineOutput(const struct freespace_MotionEngineOutput&);
+#endif
 
 	void deviceSetConfiguration(bool send_body_frames, bool send_user_frames);
 	void deviceConfigure();
@@ -93,6 +155,7 @@ protected:
 	FreespaceDeviceInfo _deviceInfo;
 	vrpn_float64 _lastBodyFrameTime;
 };
-#endif //VRPN_USE_FREESPACE
+#endif // VRPN_USE_FREESPACE
 
 #endif // VRPN_FREESPACE_H
+


### PR DESCRIPTION
This pull request updates `vrpn_Freespace` to work with the newer libfreespace version 0.7 while maintaining backward-compatibility with older versions of the library.

The `FindLibFreespace.cmake` script was modified to run a short program to check the libfreespace version. This version number is then embedded in the vrpn_Freespace.h file at configure time and new compile-time macros are provided to allow for compiling against multiple versions of libfreespace.

**N.B. I haven't tested this code beyond ensuring it compiles cleanly.**