### PR TITLE
Improve FindLibusb1 for Windows

### DIFF
--- a/cmake/FindLibusb1.cmake
+++ b/cmake/FindLibusb1.cmake
@@ -67,6 +67,7 @@ find_path(LIBUSB1_INCLUDE_DIR
 
 find_library(LIBUSB1_LIBRARY
 	NAMES
+	libusb-1.0
 	usb-1.0
 	PATHS
 	${PC_LIBUSB1_LIBRARY_DIRS}


### PR DESCRIPTION
`find_package(Libusb1)` was failing with MSVC 12 2013 Win64 when using `usb-1.0`
as the only value for the argument NAMES.

Found with `libusb-1.0`