### PR TITLE
Correct static cast in Streaming Arduino

### DIFF
--- a/vrpn_Streaming_Arduino.C
+++ b/vrpn_Streaming_Arduino.C
@@ -213,7 +213,7 @@ int vrpn_Streaming_Arduino::get_report(void)
       // seconds per character (a little under a tenth of a milli-
       // second).  So we get about 1ms of delay for every 10
       // characters.
-      long offset_usec = static_cast<long>(87 * m_buffer.size());
+      int offset_usec = static_cast<int>(87 * m_buffer.size());
       struct timeval offset = { 0 , offset_usec };
       m_timestamp = vrpn_TimevalDiff(read_time, offset);
 


### PR DESCRIPTION
Incorrect cast on `offset_usec` to 'long', given that it will only be used in `struct timeval offset` as the `tv_usec` member, of type '__darwin_suseconds_t' (aka 'int').

This build failed with the following error:
```
vrpn_Streaming_Arduino.C:217: error:
non-constant-expression cannot be narrowed from type 'long' to
'__darwin_suseconds_t' (aka 'int') in initializer list [-Wc++11-narrowing]
```

This comes from the switch to C++11, the fix is to explicitly cast the type (we know that long will still fit into int).