### PR TITLE
WIP: update novint falcon tracker

### DIFF
--- a/cmake/FindLibNifalcon.cmake
+++ b/cmake/FindLibNifalcon.cmake
@@ -7,7 +7,6 @@
 #  LIBNIFALCON_LIBRARY
 #  LIBNIFALCON_LIBUSB1_LIBRARY - Unix only
 #  LIBNIFALCON_LIBUSB1_INCLUDE_DIR - Unix only
-#  LIBNIFALCON_rt_LIBRARY - Unix only
 #
 # Non-cache variables you might use in your CMakeLists.txt:
 #  LIBNIFALCON_FOUND
@@ -20,76 +19,63 @@
 # 2010 Axel Kohlmeyer, <akohlmey@gmail.com>
 
 set(LIBNIFALCON_ROOT_DIR
-	"${LIBNIFALCON_ROOT_DIR}"
-	CACHE
-	PATH
-	"Where to start searching")
+    "${LIBNIFALCON_ROOT_DIR}"
+    CACHE
+    PATH
+    "Where to start searching")
+mark_as_advanced(LIBNIFALCON_ROOT_DIR)
 
 find_library(LIBNIFALCON_LIBRARY
-	NAMES
-	libnifalcon
-	nifalcon
-	HINTS
-	"${LIBNIFALCON_ROOT_DIR}"
-	PATH_SUFFIXES
-	include)
+    NAMES
+        libnifalcon
+        nifalcon
+    HINTS
+        "${LIBNIFALCON_ROOT_DIR}"
+    PATH_SUFFIXES
+        include)
+mark_as_advanced(LIBNIFALCON_LIBRARY)
 
 get_filename_component(_libdir "${LIBNIFALCON_LIBRARY}" PATH)
 
 find_path(LIBNIFALCON_INCLUDE_DIR
-	NAMES
-	falcon/core/FalconDevice.h
-	HINTS
-	"${_libdir}")
+    NAMES
+        falcon/core/FalconDevice.h
+    HINTS
+        "${_libdir}")
+mark_as_advanced(LIBNIFALCON_INCLUDE_DIR)
 
 set(_deps_check)
 if(NOT WIN32)
-	find_library(LIBNIFALCON_LIBUSB1_LIBRARY NAMES libusb-1.0 usb-1.0)
-	get_filename_component(_libdir "${LIBNIFALCON_LIBUSB1_LIBRARY}" PATH)
+    find_library(LIBNIFALCON_LIBUSB1_LIBRARY NAMES libusb-1.0 usb-1.0)
+    mark_as_advanced(LIBNIFALCON_LIBUSB1_LIBRARY)
 
-	find_path(LIBNIFALCON_LIBUSB1_INCLUDE_DIR
-		NAMES
-		libusb-1.0/libusb.h
-		HINTS
-		"${_libdir}")
+    get_filename_component(_libdir "${LIBNIFALCON_LIBUSB1_LIBRARY}" PATH)
 
-	find_library(LIBNIFALCON_rt_LIBRARY NAMES rt)
-	set(_deps_check
-		LIBNIFALCON_LIBUSB1_LIBRARY
-		LIBNIFALCON_LIBUSB1_INCLUDE_DIR
-		LIBNIFALCON_rt_LIBRARY)
+    find_path(LIBNIFALCON_LIBUSB1_INCLUDE_DIR
+        NAMES
+            libusb-1.0/libusb.h
+        HINTS
+            "${_libdir}")
+    mark_as_advanced(LIBNIFALCON_LIBUSB1_INCLUDE_DIR)
+
+    set(_deps_check LIBNIFALCON_LIBUSB1_LIBRARY LIBNIFALCON_LIBUSB1_INCLUDE_DIR)
+
 endif()
-
-find_package(Boost QUIET)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LibNifalcon
-	DEFAULT_MSG
-	LIBNIFALCON_LIBRARY
-	LIBNIFALCON_INCLUDE_DIR
-	Boost_INCLUDE_DIR
-	${_deps_check})
+    DEFAULT_MSG
+    LIBNIFALCON_LIBRARY
+    LIBNIFALCON_INCLUDE_DIR
+    ${_deps_check})
 
 if(LIBNIFALCON_FOUND)
-	set(LIBNIFALCON_LIBRARIES "${LIBNIFALCON_LIBRARY}")
-	set(LIBNIFALCON_LIBRARY_DIRS "${_libdir}")
-	set(LIBNIFALCON_INCLUDE_DIRS "${LIBNIFALCON_INCLUDE_DIR}" "${Boost_INCLUDE_DIR}")
+    set(LIBNIFALCON_LIBRARIES "${LIBNIFALCON_LIBRARY}")
+    set(LIBNIFALCON_INCLUDE_DIRS "${LIBNIFALCON_INCLUDE_DIR}" "${Boost_INCLUDE_DIR}")
 
-	if(NOT WIN32)
-		list(APPEND
-			LIBNIFALCON_LIBRARIES
-			"${LIBNIFALCON_LIBUSB1_LIBRARY}"
-			"${LIBNIFALCON_rt_LIBRARY}")
-		list(APPEND
-			LIBNIFALCON_INCLUDE_DIRS
-			"${LIBNIFALCON_LIBUSB1_INCLUDE_DIR}")
-	endif()
-
-	mark_as_advanced(LIBNIFALCON_ROOT_DIR)
+    if(NOT WIN32)
+        list(APPEND LIBNIFALCON_LIBRARIES "${LIBNIFALCON_LIBUSB1_LIBRARY}")
+        list(APPEND LIBNIFALCON_INCLUDE_DIRS "${LIBNIFALCON_LIBUSB1_INCLUDE_DIR}")
+    endif()
 endif()
 
-mark_as_advanced(LIBNIFALCON_INCLUDE_DIR
-	LIBNIFALCON_LIBRARY
-	LIBNIFALCON_LIBUSB1_LIBRARY
-	LIBNIFALCON_LIBUSB1_INCLUDE_DIR
-	LIBNIFALCON_rt_LIBRARY)

--- a/vrpn_Tracker_NovintFalcon.C
+++ b/vrpn_Tracker_NovintFalcon.C
@@ -150,14 +150,11 @@ public:
             int i;
             // 10 chances to load the firmware.
             for (i=0; i<FALCON_NUM_RETRIES; ++i) {
-                if(!m_falconDevice->getFalconFirmware()->loadFirmware(false, libnifalcon::NOVINT_FALCON_NVENT_FIRMWARE_SIZE, const_cast<uint8_t*>(libnifalcon::NOVINT_FALCON_NVENT_FIRMWARE)))
+                if(!m_falconDevice->getFalconFirmware()->loadFirmware(true, libnifalcon::NOVINT_FALCON_NVENT_FIRMWARE_SIZE, const_cast<uint8_t*>(libnifalcon::NOVINT_FALCON_NVENT_FIRMWARE)))
                 {
                     fprintf(stderr, "Firmware loading attempt %d failed.\n", i);
-                    // Completely close and reopen device and try again
-                    m_falconDevice->close();
-                    if(!m_falconDevice->open(devidx))
-                    {
-                        fprintf(stderr, "Cannot open falcon device %d - Lib Error Code: %d - Device Error Code: %d\n",
+                    if(i==FALCON_NUM_RETRIES-1){
+                        fprintf(stderr, "Cannot load falcon device %d firmware - Device Error Code: %d - Comm Lib Error Code: %d\n",
                                 devidx, m_falconDevice->getErrorCode(), m_falconDevice->getFalconComm()->getDeviceErrorCode());
                         return false;
                     }
@@ -170,6 +167,7 @@ public:
             }
         } else {
 #ifdef VERBOSE
+
             fprintf(stderr, "Falcon Firmware already loaded.\n");
 #endif
         }
@@ -721,9 +719,6 @@ void vrpn_Tracker_NovintFalcon::mainloop()
               break;
 
           case vrpn_TRACKER_FAIL:
-              fprintf(stderr, "NovintFalcon #%d failed, trying to reset (Try power cycle if more than 4 attempts made)\n",
-                  vrpn_NovintFalcon_Device::MASK_DEVICEIDX & m_devflags);
-              status = vrpn_TRACKER_RESETTING;
               break;
 
           default:

--- a/vrpn_Tracker_NovintFalcon.C
+++ b/vrpn_Tracker_NovintFalcon.C
@@ -113,6 +113,14 @@ public:
         fprintf(stderr, "Closing Falcon device %d.\n", m_flags & MASK_DEVICEIDX);
 #endif
         if (m_falconDevice) {
+            std::shared_ptr<libnifalcon::FalconFirmware> f;
+            f=m_falconDevice->getFalconFirmware();
+            if(f) {
+                f->setLEDStatus(libnifalcon::FalconFirmware::RED_LED |
+                                libnifalcon::FalconFirmware::BLUE_LED |
+                                libnifalcon::FalconFirmware::GREEN_LED);
+                for (int i=0; !m_falconDevice->runIOLoop() && i < FALCON_NUM_RETRIES; ++i) continue;
+            }
             m_falconDevice->close();
         }
         delete m_falconDevice;

--- a/vrpn_Tracker_NovintFalcon.C
+++ b/vrpn_Tracker_NovintFalcon.C
@@ -235,30 +235,12 @@ public:
                        return false;
 
         // we have no orientation of the effector.
-        // so we just pick one. to tell them apart
-        // more easily, we just give each a different
-        // orientation.
+        // so we just pick the identity quaternion.
         if (quat) {
-            switch (m_flags & MASK_DEVICEIDX) {
-              case 0:
-                  quat[0] =  0.0;
-                  quat[1] =  0.0;
-                  quat[2] =  1.0;
-                  quat[3] =  0.0;
-                  break;
-              case 1:
-                  quat[0] =  1.0;
-                  quat[1] =  0.0;
-                  quat[2] =  0.0;
-                  quat[3] =  0.0;
-                  break;
-              default:
-                  quat[0] =  1.0;
-                  quat[1] =  0.0;
-                  quat[2] =  0.0;
-                  quat[3] =  0.0;
-                  break;
-            }
+            quat[0] =  0.0;
+            quat[1] =  0.0;
+            quat[2] =  0.0;
+            quat[3] =  1.0;
         }
 
         if (vel_quat) {


### PR DESCRIPTION
[LibNiFalcon](https://github.com/libnifalcon/libnifalcon) is now using c++11 for arrays and pointers, [getting rid of boost](https://github.com/libnifalcon/libnifalcon/pull/31). This pull request offers:

### An update to FindLibNiFalcon.cmake to :
* Get rid of `LIBNIFALCON_LIBRARY_DIRS`, used nowhere else in VRPN
* Get rid of rt and boost not needed anymore by LibNiFalcon

### An update to vrpn_Tracker_NovintFalcon.C to :
* Update to C++11 standards in LibNiFalcon