### PR TITLE
Replace getdtablesize with sysconf call to support recent Android builds

### DIFF
--- a/vrpn_Connection.C
+++ b/vrpn_Connection.C
@@ -2495,7 +2495,15 @@ static int vrpn_start_server(const char *machine, char *server_name, char *args,
 
         /* Close all files except stdout and stderr. */
         /* This prevents a hung child from keeping devices open */
+#if defined(__ANDROID__)
+	// When building for Android, and specifically for support of
+	// VR/GearVR, newer versions of Android (KitKat and up) are
+	// required. getdtablesize is not provided by these platforms.
+        num_descriptors = sysconf(_SC_OPEN_MAX);
+#else 
         num_descriptors = getdtablesize();
+#endif
+
         for (loop = 0; loop < num_descriptors; loop++) {
             if ((loop != 1) && (loop != 2)) {
                 close(loop);


### PR DESCRIPTION
More recent versions of Android do not contain getdtablesize. This change adds
code that uses sysconf to query the num_descriptors using sysconf rather than getdtablesize.
This change allows the client library to be built for GearVR-supported versions of Android.