### PR TITLE
Adding support to find libusb-1.0.20 on Windows

### DIFF
--- a/cmake/FindLibusb1.cmake
+++ b/cmake/FindLibusb1.cmake
@@ -35,11 +35,11 @@ if(WIN32)
 	program_files_fallback_glob(_dirs "LibUSB-Win32")
 	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 		if(MSVC)
-			set(_lib_suffixes lib/msvc_x64)
+			set(_lib_suffixes lib/msvc_x64 MS64/static)
 		endif()
 	else()
 		if(MSVC)
-			set(_lib_suffixes lib/msvc)
+			set(_lib_suffixes lib/msvc MS32/static)
 		elseif(COMPILER_IS_GNUCXX)
 			set(_lib_suffixes lib/gcc)
 		endif()
@@ -62,6 +62,7 @@ find_path(LIBUSB1_INCLUDE_DIR
 	HINTS
 	"${LIBUSB1_ROOT_DIR}"
 	PATH_SUFFIXES
+	include/libusb-1.0
 	include
 	libusb-1.0)
 
@@ -73,6 +74,8 @@ find_library(LIBUSB1_LIBRARY
 	${PC_LIBUSB1_LIBRARY_DIRS}
 	${PC_LIBUSB1_LIBDIR}
 	${_dirs}
+	HINTS
+	"${LIBUSB1_ROOT_DIR}"
 	PATH_SUFFIXES
 	${_lib_suffixes})
 


### PR DESCRIPTION
Improved FindLibusb1.cmake to find libusb version 1.0.20:

1) Append new library path to _lib_suffixes: `MS64/static` & `MS32/static`
2) Append path suffix for libusb-1.0 header file: `include/libusb-1.0`
2) Add `LIBUSB1_ROOT_DIR` as path `HINT` for find_library

This changes are backward compatible to older versions of libusb