### PR TITLE
Adding Swig typemaps for vrpn_float64 and vrpn_uint32 to enable prope…

### DIFF
--- a/python_vrpn/vrpn_Analog.i
+++ b/python_vrpn/vrpn_Analog.i
@@ -10,6 +10,13 @@
 
 %module vrpn_Analog
 
+%typemap(in) vrpn_float64 {
+   $1 = PyFloat_AsDouble($input);
+}
+%typemap(in) vrpn_uint32 {
+   $1 = PyInt_AsLong($input);
+}
+
 %{
 #include "../vrpn_Types.h"
 #include "../vrpn_BaseClass.h"

--- a/python_vrpn/vrpn_Auxiliary_Logger.i
+++ b/python_vrpn/vrpn_Auxiliary_Logger.i
@@ -9,6 +9,14 @@
 //
 
 %module vrpn_Auxiliary_Logger
+
+%typemap(in) vrpn_float64 {
+   $1 = PyFloat_AsDouble($input);
+}
+%typemap(in) vrpn_uint32 {
+   $1 = PyInt_AsLong($input);
+}
+
 %{
 #include "../vrpn_Types.h"
 #include "../vrpn_BaseClass.h"

--- a/python_vrpn/vrpn_Button.i
+++ b/python_vrpn/vrpn_Button.i
@@ -9,6 +9,14 @@
 //
 
 %module vrpn_Button
+
+%typemap(in) vrpn_float64 {
+   $1 = PyFloat_AsDouble($input);
+}
+%typemap(in) vrpn_uint32 {
+   $1 = PyInt_AsLong($input);
+}
+
 %{
 #include "../vrpn_Types.h"
 #include "../vrpn_BaseClass.h"

--- a/python_vrpn/vrpn_Dial.i
+++ b/python_vrpn/vrpn_Dial.i
@@ -9,6 +9,14 @@
 //
 
 %module vrpn_Dial
+
+%typemap(in) vrpn_float64 {
+   $1 = PyFloat_AsDouble($input);
+}
+%typemap(in) vrpn_uint32 {
+   $1 = PyInt_AsLong($input);
+}
+
 %{
 #include "../vrpn_Types.h"
 #include "../vrpn_Dial.h"

--- a/python_vrpn/vrpn_ForceDevice.i
+++ b/python_vrpn/vrpn_ForceDevice.i
@@ -9,6 +9,14 @@
 //
 
 %module vrpn_ForceDevice
+
+%typemap(in) vrpn_float64 {
+   $1 = PyFloat_AsDouble($input);
+}
+%typemap(in) vrpn_uint32 {
+   $1 = PyInt_AsLong($input);
+}
+
 %{
 #include "../vrpn_Types.h"
 #include "../vrpn_BaseClass.h"

--- a/python_vrpn/vrpn_Poser.i
+++ b/python_vrpn/vrpn_Poser.i
@@ -10,6 +10,13 @@
 
 %module vrpn_Poser
 
+%typemap(in) vrpn_float64 {
+   $1 = PyFloat_AsDouble($input);
+}
+%typemap(in) vrpn_uint32 {
+   $1 = PyInt_AsLong($input);
+}
+
 %{
 #include "../vrpn_Types.h"
 #include "../vrpn_BaseClass.h"

--- a/python_vrpn/vrpn_Text.i
+++ b/python_vrpn/vrpn_Text.i
@@ -9,6 +9,14 @@
 //
 
 %module vrpn_Text
+
+%typemap(in) vrpn_float64 {
+   $1 = PyFloat_AsDouble($input);
+}
+%typemap(in) vrpn_uint32 {
+   $1 = PyInt_AsLong($input);
+}
+
 %{
 #include "../vrpn_Types.h"
 #include "../vrpn_BaseClass.h"

--- a/python_vrpn/vrpn_Tracker.i
+++ b/python_vrpn/vrpn_Tracker.i
@@ -9,6 +9,14 @@
 //
 
 %module vrpn_Tracker
+
+%typemap(in) vrpn_float64 {
+   $1 = PyFloat_AsDouble($input);
+}
+%typemap(in) vrpn_uint32 {
+   $1 = PyInt_AsLong($input);
+}
+
 %{
 #include "../vrpn_Types.h"
 #include "../vrpn_BaseClass.h"


### PR DESCRIPTION
…r type translation for function calls.  Added an extension method to the vrpn_Analog_Output Python wrapping that should not be needed according to the spec, but tracing through the generated code shows that an internal function that switches between the 3-parameter and 4-parameter version of the function is itself always called with 4 parameters, even when the python code itself calls it with 3.