### PR TITLE
Updated Phasespace Trackers to support libowlsock major version 5.  Th…

### DIFF
--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -1531,102 +1531,125 @@
 
 #vrpn_Button_NI_DIO24	Button0	1
 
-
 ##############################################################################
-#PhaseSpace OWL server.  This device type is not compiled by default, since
-#it uses a proprietary library.  However, you can get it to compile by
-#defining VRPN_INCLUDE_PHASESPACE and including the appropriate libraries
-#and headers when compiling (See vrpn_Configure.h).
+# PhaseSpace Impulse system.  This device type is not compiled by default, since
+# it uses a proprietary library.  However, you can get it to compile by 
+# defining VRPN_INCLUDE_PHASESPACE and including the appropriate libraries
+# and headers when compiling (See vrpn_Configure.h).
+# 
+# Arguments:
+#        char	tracker_name[]   # Tracker0, Tracker1, ... etc
+#        [Additional lines specifying tracker configuration]
+# 
+# The section following the Tracker declaration is a tag delimited set of
+# lines which specify system configuration and vrpn sensors.  The section begins
+# with an <owl> tag and ends with a </owl> tag.  Each tag must be on a separate
+# line. (see below)
+# 
+# Each line in the specification section is a white-space separated set of
+# key-value pairs.  At most one sensor is defined per line.  The sensor and type
+# keys are mandatory.  Other keys are are required based on the type.
 #
-#Arguments:
-#       char	name_of_this_tracker[]   #Tracker0, Tracker1, ... etc
-#       char    location_of_OWL_device[] #typically localhost, or ip address
-#       float   frame_rate               #between 0.0 and 480.0
-#       int     read_till_most_recent    #0 or 1.
-#       int     slave_mode               #0 or 1.
-#       [Additional lines specifying markers and rigid bodies]
+# Comments can be embedded with the '#' character.
 #
-#Specifying a frequency >0 will start streaming immediately at startup.
-#To delay this, set the frequency to zero and adjust the update rate later.
+# Example:
+# 
+#       vrpn_Tracker_PhaseSpace Tracker0 
+#       <owl>
+#       device="192.168.1.1"
+#       frequency=960
+#       slave=0
+#       drop_frames=0
+#       scale=0.001
+#       debug=0
 #
-#Specifying 1 for read_till_most_recent will cause the server to drop frames
-#in order to get the most recent data on every run through the mainloop.
-#This may be desirable for most VR applications and for slower machines.
+#       sensor=0 type=point tracker=0 led=0  # this is a comment
+#       sensor=1 type=point tracker=0 led=1  # map sensor 1 to led 1 on tracker 0
 #
-#The format of the additional lines is as follows:
+#       sensor=2 type=rigid_body tracker=1 # designate tracker 1 as a rigid body on sensor 2
+#       sensor=3 type=point tracker=1 led=2 pos=0,0,0      # add led 2 to rigid body on tracker 1
+#       sensor=4 type=point tracker=1 led=3 pos=100,0,0    # add led 3 to rigid body on tracker 1
+#       sensor=5 type=point tracker=1 led=4 pos=0,100,0    # add led 4 to rigid body on tracker 1
+#       sensor=6 type=point tracker=1 led=5 pos=0,0,100    # add led 5 to rigid body on tracker 1
+#       </owl>
 #
-#Example:
+# Key Definitions
+# ======================
 #
-#vrpn_Tracker_PhaseSpace Tracker0 localhost 480.0 1 0
+# device
+#    A string specifying the IP address of the Impulse server to connect to. 
+#
+# frequency
+#    A floating-point number specifying the system streaming frequency.
+#    Usually 480 or 960.
+#
+# slave
+#    An integer specifying whether to enable slave mode.
+#    Set to 0 to disable, 1 to enable. If slave mode is enabled,  unspecified
+#    markers are assigned an arbitrary sensor number.
+#
+# drop_frames
+#    An integer. Set to zero to disable.  Specifying 1 for drop_frames will
+#    cause the server to drop frames in order to get the most recent data on
+#    every run through the mainloop. This may be desirable for most VR
+#    applications and for slower machines. 
+#
+# debug
+#    An integer.  Zero to disable.  Specifying 1 for debug will cause the server
+#    to print out verbose debugging output.
+#
+# scale
+#    The floating-point factor to scale incoming positional data by.  The default
+#    is 0.001.
+#
+# sensor
+#    The vrpn sensor number.
+#
+# type
+#    A string which specifies what type the sensor is. Required if sensor is
+#    specified.  The following types are supported: 
+#        point
+#        rigid
+#        rigid_body (deprecated)
+#
+# tracker
+#    An integer which specifies The Impulse tracker id of an led or rigid body.
+#    Required if type is "point" or "rigid".
+#
+# led
+#    An integer which specifies the led id of a sensor.
+#    Required if type is "point".
+#    
+# pos
+#    An optional comma-separated list of three floating-point numbers specifying
+#    the 3D position of a marker on a rigid body.  No spaces.  Valid if type is
+#    "point".  Specifying positions is only valid if the tracker number is set
+#    to a rigid body.  The units MUST be in millimeters, regardless of scale
+#    setting.
+# 
+# init
+#    An optional comma-separated list of four floating-point numbers specifying
+#    kalman parameters for a rigid body.  Valid if type is "rigid_body".
+#
+#
+# For support, questions, comments, or bug reports please send emails 
+# to:  support@phasespace.com
+# 
+#vrpn_Tracker_PhaseSpace Tracker0 
 #<owl>
-#0 :     rbnew
-#1 :     rb+     0      0       300     0
-#2 :     rb+     1      300     0       0
-#3 :     rb+     2      -300    0       0
-#4 :     rb+     3      0       76      -200
-#5 :     pt      4
-#6 :     pt      5
-#7 :     pt      6    #this is a comment
-#8 :     pt      8
-#9 :     pt      9
-#</owl>
-#
-#
-#
-#       In regular expression syntax:
-#       sensornumber : spectype led_id [xcoord  ycoord  zcoord]
-#
-#       The <owl> and </owl> tags indicate the start and end of the marker
-#       and rigid body specifications.  Each line inside the tags correspond
-#       to a sensor specified by the first number in the line.  Register
-#       callbacks as necessary.  The # character will cause the rest of
-#       the line to be ignored.  Do not assign duplicate sensors.
-#
-#       There are 4 spectypes: "rbnew", "rb+", and "pt".
-#
-#       "pt" indicates a normal marker specification.
-#       The number following it indicates the led id to assign to that sensor.
-#       No further arguments are needed for the rest of the line. The vrpn
-#       server will return position data for that marker but no orientation
-#       data.
-#
-#       "rbnew" indicates a new rigid body specification.  The lines following
-#       it must be "rb+" lines, indicating the addition of markers to the
-#       rigid body.  The "rb+" lines must have the x,y, and z coordinates of
-#       the rigid body marker specified after the led id.  The rigid body
-#       itself is assigned the sensor of the "rbnew" line, and the markers
-#       in the rigid body are given the sensor numbers of the "rb+" lines.
-#       The rigid body specification continues until another "rbnew" line is
-#       encountered or until the </owl> tag.  If "pt" lines are mixed in, they
-#       do not affect the rigid body. Rigid bodies will return an orientation
-#       as well as positional data.
-#
-#       Empty or invalid lines inside the <owl> and </owl> tags are also
-#       ignored.
-#
-#       Care must be taken to AVOID specifying the same led id or sensor twice,
-#       sensors and led ids should be unique.
-#
-#       The OWL server (not just the vrpn server) must still be configured to
-#       track the specified markers.  Consult the PhaseSpace documentation to
-#       see how.
-#
-#
-#       Velocities and accelerations are not currently supported.
-#
-#       The frequency of streaming can be varied with set_update_rate()
-#       in vrpn_Tracker_Remote. To stop streaming, set the update rate to
-#       zero.
-#
-#       For support, questions, comments, or bug reports please send emails
-#       to:  support@phasespace.com
-
-#vrpn_Tracker_PhaseSpace Tracker0 localhost 480.0 1 0
-#<owl>
-#0 :     pt      0      #to sensor 0 assign led 0
-#1 :     pt      1      #to sensor 1 assign led 1
-#2 :     pt      2      #to sensor 2 assign led 2
-#3 :     pt      3      #to sensor 3 assign led 3
+#device="192.168.1.200"
+#frequency=480
+#slave=0
+#drop_frames=0
+#scale=0.001
+#sensor=0 type=point led=0
+#sensor=1 type=point led=1
+#sensor=2 type=point led=2
+#sensor=3 type=point led=3
+#sensor=4 type=point led=4
+#sensor=5 type=point led=5
+#sensor=6 type=point led=6
+#sensor=7 type=point led=7
 #</owl>
 
 ################################################################################

--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -1637,7 +1637,7 @@
 # 
 #vrpn_Tracker_PhaseSpace Tracker0 
 #<owl>
-#device="192.168.1.200"
+#device="192.168.1.230"
 #frequency=480
 #slave=0
 #drop_frames=0

--- a/vrpn_Tracker_PhaseSpace.C
+++ b/vrpn_Tracker_PhaseSpace.C
@@ -1,82 +1,253 @@
+/*
+  PhaseSpace, Inc 2015
+  vrpn_Tracker_PhaseSpace.C
+
+  ChangeLog
+  =================
+  20170201
+  * removed some extraneous comments
+
+  20151008
+  * slave mode now uses cfg specs to assign sensors to markers and rigids.
+    Unassigned devices will still be assigned arbitrarily.
+
+  20150818
+  * Update to libowl2 API for X2e device support, removed support for Impulse
+  * removed stylus and button support
+  * removed maximum rigid and marker limitations
+  * vrpn.cfg:  x,y, and z parameters for point sensors changed to single pos
+    parameter
+  * vrpn.cfg:  k1,k2,k3,k4 parameters for rigid sensors changed to single init
+    parameter
+
+  */
 #include "vrpn_Tracker_PhaseSpace.h"
 
+#include <errno.h>
+#include <math.h>
+
+#include <limits>
+#include <string>
+#include <sstream>
+#include <algorithm>
+#include <map>
+#include <vector>
+
 #define MM_TO_METERS (0.001)
+#define MSGBUFSIZE 1024
 
 #ifdef VRPN_INCLUDE_PHASESPACE
-//#define DEBUG
 
 //
-inline void frame_to_time(int frame, float frequency, struct timeval &time) {
-  float t = frame / frequency;
-  time.tv_sec = int(t);
-  time.tv_usec = int((t - time.tv_sec)*1E6);
+struct SensorInfo {
+  vrpn_int32 sensor_id; // vrpn sensor
+
+  int type;             // owl tracker type
+  uint32_t tracker;          // tracker_id
+  uint32_t id;               // marker_id
+  std::string opt;
+
+  size_t search_hint;
+
+  SensorInfo()
+  {
+    type = -1;
+    tracker = 0;
+    id = 0;
+    opt = "";
+    search_hint = std::numeric_limits<uint32_t>::max();
+  }
+};
+
+
+//
+typedef std::vector<SensorInfo> Sensors;
+
+
+//
+bool operator<(const SensorInfo& a, const SensorInfo& b)
+{
+  if(a.type < b.type) return true;
+  if(a.type > b.type) return false;
+  return a.id < b.id;
 }
 
 //
-vrpn_Tracker_PhaseSpace::vrpn_Tracker_PhaseSpace(const char *name, vrpn_Connection *c, const char* device, float frequency,int readflag, int slave)
-  : vrpn_Tracker(name,c)
+class vrpn_Tracker_PhaseSpace::SensorManager
 {
-#ifdef DEBUG
-  printf("%s %s %s %f %d\n", __PRETTY_FUNCTION__, name, device, frequency, readflag);
-#endif
+protected:
+  Sensors _v;
+
+public:
+  void add(const SensorInfo& s)
+  {
+    _v.push_back(s);
+    std::sort(_v.begin(), _v.end());
+  }
+
+  const SensorInfo* get_by_sensor(int sensor_id)
+  {
+    for(size_t i = 0; i < _v.size(); i++)
+      if(_v[i].sensor_id == sensor_id) return &_v[i];
+    return NULL;
+  }
+
+  Sensors::iterator begin()
+  {
+    return _v.begin();
+  }
+
+  Sensors::iterator end()
+  {
+    return _v.end();
+  }
+};
+
+
+// ctor
+vrpn_Tracker_PhaseSpace::vrpn_Tracker_PhaseSpace(const char *name, vrpn_Connection *c)
+  : vrpn_Tracker(name ,c),
+    vrpn_Button_Filter(name, c),
+    vrpn_Clipping_Analog_Server(name, c),
+    debug(false),
+    drop_frames(false),
+    smgr(new SensorManager())
+{
+  // TODO fix
+  //num_buttons = vrpn_BUTTON_MAX_BUTTONS;
+  num_buttons = 0;
 
   if(d_connection) {
     // Register a handler for the update change callback
     if (register_autodeleted_handler(update_rate_id, handle_update_rate_request, this, d_sender_id))
       fprintf(stderr,"vrpn_Tracker: Can't register workspace handler\n");
   }
-
-  this->slave = slave;
-  this->frequency = frequency;
-
-  numRigids = 0;
-  numMarkers = 0;
-  markers.reserve(VRPN_PHASESPACE_MAXMARKERS);
-  rigids.reserve(VRPN_PHASESPACE_MAXRIGIDS);
-
-  int owlflag = 0;
-  if(slave) owlflag |= OWL_SLAVE;
-
-  int ret = owlInit(device,owlflag);
-  if(ret != owlflag) {
-    fprintf(stderr, "owlInit error: 0x%x\n", ret);
-    owlRunning = false;
-    return;
-  } else {
-    owlRunning = true;
-  }
-
-  char msg[512];
-  if(owlGetString(OWL_VERSION,msg)) {
-    printf("OWL version: %s\n",msg);
-  } else {
-    printf("Unable to query OWL version.\n");
-  }
-
-  if(!slave) {
-    //The master point tracker is index 0.  So all rigid trackers will start from 1.
-    owlTrackeri(0, OWL_CREATE, OWL_POINT_TRACKER);
-    if(!owlGetStatus()) {
-      fprintf(stderr,"Error: Unable to create main point tracker.\n");
-      return;
-    }
-  } else {
-    printf("Ignoring tracker creation in slave mode.\n");
-  }
-
-  readMostRecent = readflag ? true : false;
-  frame = 0;
 }
 
-//
+
+// dtor
 vrpn_Tracker_PhaseSpace::~vrpn_Tracker_PhaseSpace()
 {
-#ifdef DEBUG
-  printf("%s\n", __PRETTY_FUNCTION__);
-#endif
+  context.done();
+  context.close();
+}
 
-  if(owlRunning)
-    owlDone();
+
+//
+bool vrpn_Tracker_PhaseSpace::InitOWL()
+{
+  printf("connecting to OWL server at %s...\n", device.c_str());
+
+  std::string init_options = "event.markers=1 event.rigids=1";
+  if(options.length()) init_options += " " + options;
+
+  if(drop_frames) printf("drop_frames enabled\n");
+
+  // connect to Impulse server
+  if(context.open(device) <= 0)
+    {
+      fprintf(stderr, "owl connect error: %s\n", context.lastError().c_str());
+      return false;
+    }
+
+  //TODO reimplement
+  //// query and print server version
+  //char msg[512];
+  //if(owlGetString(OWL_VERSION,msg)) {
+  //  printf("OWL version: %s\n",msg);
+  //} else {
+  //  printf("Unable to query OWL version.\n");
+  //}
+
+  if(context.initialize(init_options) <= 0)
+    {
+      fprintf(stderr, "owl init error: %s\n", context.lastError().c_str());
+      return false;
+    }
+
+  if(options.find("timebase=") == std::string::npos) context.timeBase(1, 1000000);
+  if(options.find("scale=") == std::string::npos) context.scale(MM_TO_METERS);
+
+  if(context.lastError().length())
+    {
+      fprintf(stderr, "owl error: %s\n", context.lastError().c_str());
+      return false;
+    }
+
+  int slave = context.property<int>("slave");
+
+  if(slave) printf("slave mode enabled.\n");
+  else if(!create_trackers()) return false;
+
+  printf("owl initialized\n");
+  return true;
+}
+
+
+//
+bool vrpn_Tracker_PhaseSpace::create_trackers()
+{
+  if(debug) printf("creating trackers...\n");
+
+  // create trackers
+  int nr = 0;
+  int nm = 0;
+  std::vector<uint32_t> ti;
+
+  // create rigid trackers
+  if(debug) printf("rigids:\n");
+  for(Sensors::iterator s = smgr->begin(); s != smgr->end(); s++)
+    {
+      if(s->type != OWL::Type::RIGID) continue;
+      nr++;
+      if(std::find(ti.begin(), ti.end(), s->tracker) != ti.end())
+        {
+          fprintf(stderr, "rigid tracker %d already defined\n", s->tracker);
+          continue;
+        }
+
+      printf("creating rigid tracker %d\n", s->tracker);
+      std::string type = "rigid";
+      std::stringstream name; name << type << nr;
+      if(debug) printf("    type=%s id=%d name=%s options=\'%s\'\n", type.c_str(), s->tracker, name.str().c_str(), s->opt.c_str());
+
+      if(!context.createTracker(s->tracker, type, name.str(), s->opt))
+        {
+          fprintf(stderr, "tracker creation error: %s\n", context.lastError().c_str());
+          return false;
+        }
+      ti.push_back(s->tracker);
+    }
+
+  // create point trackers
+  if(debug) printf("markers:\n");
+  for(Sensors::iterator s = smgr->begin(); s != smgr->end(); s++)
+    {
+      if(s->type != OWL::Type::MARKER) continue;
+      nm++;
+      if(std::find(ti.begin(), ti.end(), s->tracker) == ti.end())
+        {
+          printf("creating point tracker %d\n", s->tracker);
+          std::string type = "point";
+          std::stringstream name; name << type << nm;
+          ti.push_back(s->tracker);
+          context.createTracker(s->tracker, type, name.str());
+        }
+      if(!context.assignMarker(s->tracker, s->id, "", s->opt))
+        {
+          fprintf(stderr, "marker assignment error: %s\n", context.lastError().c_str());
+          return false;
+        }
+      if(debug) printf("    id=%d tracker=%d options=\'%s\'\n", s->id, s->tracker, s->opt.c_str());
+    }
+
+  if(context.lastError().length())
+    {
+      fprintf(stderr, "tracker creation error: %s\n", context.lastError().c_str());
+      return false;
+    }
+
+  return true;
 }
 
 
@@ -86,358 +257,745 @@ vrpn_Tracker_PhaseSpace::~vrpn_Tracker_PhaseSpace()
 void vrpn_Tracker_PhaseSpace::mainloop()
 {
   get_report();
-
-  // Call the generic server mainloop, since we are a server
   server_mainloop();
   return;
 }
 
+
 //
-bool vrpn_Tracker_PhaseSpace::addMarker(int sensor,int led_id)
+std::string trim(char* line, int len)
 {
-#ifdef DEBUG
-  printf("%s %d %d\n", __PRETTY_FUNCTION__, sensor, led_id);
-#endif
+  // cut off leading whitespace
+  int s, e;
+  for(s = 0; isspace(line[s]) && s < len; s++);
+  // cut off comments and trailing whitespace
+  e = s;
+  for(int i = s; line[i] && i < len; i++)
+    {
+      if(line[i] == '#') break;
+      if(!isspace(line[i])) e = i+1;
+    }
+  return std::string(line+s, e-s);
+}
 
-  if(!owlRunning) return false;
-  if(slave) return false;
 
-  if(numMarkers >= VRPN_PHASESPACE_MAXMARKERS) {
-    fprintf(stderr, "Error: Maximum markers (%d) exceeded.\n", VRPN_PHASESPACE_MAXMARKERS);
+//
+bool read_int(const char* str, int &i)
+{
+  if(!str) return false;
+  errno = 0;
+  char* endptr = NULL;
+  i = strtol(str, &endptr, 10);
+  if(*endptr || errno) {
+    fprintf(stderr, "Error, expected an integer but got token: \"%s\"\n", str);
     return false;
   }
-
-  owlMarkeri(MARKER(0,sensor),OWL_SET_LED,led_id);
-
-  if(!owlGetStatus())
-    return false;
-
-  numMarkers++;
   return true;
 }
 
-/*
-This function must only be called after startNewRigidBody has been called.
-*/
-bool vrpn_Tracker_PhaseSpace::addRigidMarker(int sensor, int led_id, float x, float y, float z)
+
+//
+bool read_uint(const char* str, uint32_t &i)
 {
-#ifdef DEBUG
-  printf("%s %d %d %f %f %f\n", __PRETTY_FUNCTION__, sensor, led_id, x, y, z);
-#endif
-
-  if(!owlRunning) return false;
-  if(slave) return false;
-
-  if(numRigids == 0) {
-    fprintf(stderr, "Error: Attempting to add rigid body marker with no rigid body defined.");
+  if(!str) return false;
+  errno = 0;
+  char* endptr = NULL;
+  i = strtoul(str, &endptr, 10);
+  if(*endptr || errno) {
+    fprintf(stderr, "Error, expected an unsigned integer but got token: \"%s\"\n", str);
     return false;
   }
-  if(numMarkers >= VRPN_PHASESPACE_MAXMARKERS) {
-    fprintf(stderr, "Error: Maximum markers (%d) exceeded.\n", VRPN_PHASESPACE_MAXMARKERS);
-    return false;
-  }
-
-  float xyz[3];
-  xyz[0] = x;
-  xyz[1] = y;
-  xyz[2] = z;
-
-  owlMarkeri(MARKER(numRigids,sensor),OWL_SET_LED,led_id);
-  owlMarkerfv(MARKER(numRigids,sensor),OWL_SET_POSITION,&xyz[0]);
-
-  if(!owlGetStatus())
-    return false;
-
-  numMarkers++;
   return true;
 }
 
-/*
-Starts a new rigid body definition and creates a tracker for it on
-the server.  Use addRigidMarker() to add markers to the tracker.
-Trackers must be disabled (using enableTracker(false)) before being
-modified or created.
-*/
-bool vrpn_Tracker_PhaseSpace::startNewRigidBody(int sensor)
+
+//
+bool read_bool(const char* str, bool &b)
 {
-#ifdef DEBUG
-  printf("%s %d\n", __PRETTY_FUNCTION__, sensor);
-#endif
+  if(!str) return false;
+  std::string s(str);
+  if(s == "true") {
+    b = true;
+    return true;
+  } else if(s == "false") {
+    b = false;
+    return true;
+  }
+  int i = 0;
+  bool ret = read_int(str, i);
+  b = i ? true : false;
+  return ret;
+}
 
-  if(!owlRunning) return false;
-  if(slave) return false;
 
-  if(numRigids >= VRPN_PHASESPACE_MAXRIGIDS) {
-    fprintf(stderr, "error: maximum rigid bodies (%d) exceeded\n", VRPN_PHASESPACE_MAXRIGIDS);
+//
+bool read_float(const char* str, float &f)
+{
+  if(!str) return false;
+  errno = 0;
+  char* endptr = NULL;
+  f = (float) strtod(str, &endptr);
+  if(*endptr || errno) {
+    fprintf(stderr, "Error, expected a float but got token: \"%s\"\n", str);
     return false;
   }
-
-  owlTrackeri(++numRigids, OWL_CREATE, OWL_RIGID_TRACKER);
-
-  if(!owlGetStatus()) {
-    numRigids--;
-    return false;
-  }
-
-  //remember the sensor that this rigid tracker is mapped to.
-  r2s_map[numRigids] = sensor;
   return true;
 }
 
-/*
-Enables all the trackers and sets the streaming frequency.
-Note: Trackers according to VRPN and Trackers as defined by OWL
-are two entirely different things.
-*/
-bool vrpn_Tracker_PhaseSpace::enableTracker(bool enable)
+
+// TODO: Replace all of this junk with <regex> once it is standard in gcc
+class ConfigParser
 {
-#ifdef DEBUG
-  printf("%s %d\n", __PRETTY_FUNCTION__, enable);
-#endif
+protected:
+  struct Spec {
+    std::string key;
+    std::string type;
+    void* dest;
+    bool required;
+  };
 
-  if(!owlRunning) return false;
+  std::map <std::string, std::string> keyvals;
+  std::stringstream _error;
 
-  // Scale the reports for this tracker to be in meters rather than
-  // in MM, to match the VRPN standard.
-  owlScale(MM_TO_METERS);
+public:
 
-  if(!slave) {
-    int option = enable ? OWL_ENABLE : OWL_DISABLE;
-    owlTracker(0,option); //enables/disables the point tracker
-    if(!owlGetStatus())
-      return false;
+  std::string error()
+  {
+    return _error.str();
+  }
 
-    //enable/disable the rigid trackers
-    for(int i = 1; i <= numRigids; i++) {
-      owlTracker(i,option);
-      if(!owlGetStatus())
+  bool contains(const std::string &key)
+  {
+    return keyvals.find(key) != keyvals.end();
+  }
+
+  std::string join()
+  {
+    std::stringstream s;
+    for(std::map<std::string, std::string>::iterator i = keyvals.begin(); i != keyvals.end(); i++)
+      s << (i==keyvals.begin()?"":" ") << i->first << "=" << i->second;
+    return s.str();
+  }
+
+  //
+  bool parse(SensorInfo &si)
+  {
+    _error.str("");
+
+    std::string spec_type;
+    float x=std::numeric_limits<float>::quiet_NaN();
+    float y=std::numeric_limits<float>::quiet_NaN();
+    float z=std::numeric_limits<float>::quiet_NaN();
+
+    Spec spec_marker[] = {
+      { "led", "uint32_t", &si.id, true },
+      { "tracker", "uint32_t", &si.tracker, false },
+      { "x", "float", &x, false },
+      { "y", "float", &y, false },
+      { "z", "float", &z, false },
+      { "", "", NULL, false } // sentinel
+    };
+
+    Spec spec_rigid[] = {
+      { "tracker", "uint32_t", &si.tracker, true },
+      { "", "", NULL, false } // sentinel
+    };
+
+    if(pop_int("sensor", si.sensor_id))
+      {
+        _error << "required key 'sensor' not found";
         return false;
-    }
-  }
-
-  if(enable) {
-    setFrequency(frequency);
-    owlSetInteger(OWL_EVENTS, OWL_ENABLE);
-    owlSetInteger(OWL_STREAMING,OWL_ENABLE);
-    if(!owlGetStatus())
-      return false;
-    printf("Streaming enabled.\n");
-  } else {
-    owlSetInteger(OWL_EVENTS, OWL_DISABLE);
-    owlSetInteger(OWL_STREAMING,OWL_DISABLE);
-    if(!owlGetStatus())
-      return false;
-    printf("Streaming disabled.\n");
-  }
-  return true;
-}
-
-int debugcounter = 0;
-
-//
-int vrpn_Tracker_PhaseSpace::read_frame(void)
-{
-  int ret = 0;
-  char buffer[1024];
-  OWLEvent e = owlGetEvent();
-  switch(e.type) {
-  case 0:
-    break;
-  case OWL_DONE:
-    owlRunning = false;
-    send_text_message("owl stopped\n", timestamp, vrpn_TEXT_ERROR);
-    return 0;
-  case OWL_FREQUENCY:
-    owlGetFloatv(OWL_FREQUENCY, &frequency);
-    fprintf(stdout, "frequency: %d\n", frequency);
-    break;
-  case OWL_BUTTONS: break;
-  case OWL_MARKERS:
-    markers.resize(VRPN_PHASESPACE_MAXMARKERS);
-    ret = owlGetMarkers(&markers.front(), markers.size());
-    if(ret > 0) markers.resize(ret);
-    break;
-  case OWL_RIGIDS:
-    rigids.resize(VRPN_PHASESPACE_MAXRIGIDS);
-    ret = owlGetRigids(&rigids.front(), rigids.size());
-    if(ret > 0) rigids.resize(ret);
-    break;
-  case OWL_COMMDATA:
-    owlGetString(OWL_COMMDATA, buffer);
-    break;
-  case OWL_TIMESTAMP:
-    owlGetIntegerv(OWL_TIMESTAMP, &ret);
-    break;
-  case OWL_PLANES:
-    planes.resize(VRPN_PHASESPACE_MAXPLANES);
-    ret = owlGetPlanes(&planes.front(), planes.size());
-    if(ret > 0) planes.resize(ret);
-    break;
-  case OWL_DETECTORS:
-    detectors.resize(VRPN_PHASESPACE_MAXDETECTORS);
-    ret = owlGetDetectors(&detectors.front(), detectors.size());
-    if(ret > 0) detectors.resize(ret);
-    break;
-  case OWL_PEAKS:
-    peaks.resize(VRPN_PHASESPACE_MAXPEAKS);
-    ret = owlGetPeaks(&peaks.front(), peaks.size());
-    if(ret > 0) peaks.resize(ret);
-    break;
-  case OWL_IMAGES:
-    images.resize(VRPN_PHASESPACE_MAXIMAGES);
-    ret = owlGetImages(&images.front(), images.size());
-    if(ret > 0) images.resize(ret);
-    break;
-  case OWL_CAMERAS:
-    cameras.resize(VRPN_PHASESPACE_MAXCAMERAS);
-    ret = owlGetCameras(&cameras.front(), cameras.size());
-    if(ret > 0) cameras.resize(ret);
-    break;
-  case OWL_STATUS_STRING: break;
-  case OWL_CUSTOM_STRING: break;
-  case OWL_FRAME_NUMBER:
-    if(owlGetIntegerv(OWL_FRAME_NUMBER, &ret))
-      frame = ret;
-    break;
-  default:
-    fprintf(stderr, "unsupported OWLEvent type: 0x%x\n", e.type);
-    break;
-  }
-  return e.type;
-}
-
-//
-int vrpn_Tracker_PhaseSpace::get_report(void)
-{
-  if(!owlRunning) return 0;
-
-  int maxiter = 1;
-  if(readMostRecent) maxiter = 1024; // not technically most recent, but if the client is slow, avoids infinite loop.
-
-  int ret = 1;
-  int oldframe = frame;
-  for(int i = 0; i < maxiter && ret; i++) {
-    int cframe = frame;
-    while(ret && cframe == frame) {
-      ret = read_frame();
-    }
-  }
-  // no new data? abort.
-  if(oldframe == frame)
-    return 0;
-
-#ifdef DEBUG
-  char buffer[1024];
-  owlGetString(OWL_FRAME_BUFFER_SIZE, buffer);
-  printf("%s\n", buffer);
-#endif
-
-  for(int i = 0; i < markers.size(); i++)
-    {
-      if(markers[i].cond <= 0) continue;
-
-      //set the sensor
-      d_sensor = markers[i].id;
-
-      pos[0] = markers[i].x;
-      pos[1] = markers[i].y;
-      pos[2] = markers[i].z;
-
-      //raw positions have no rotation
-      d_quat[0] = 0;
-      d_quat[1] = 0;
-      d_quat[2] = 0;
-      d_quat[3] = 1;
-
-      // send time out in OWL time
-      if(frequency) frame_to_time(frame, frequency, timestamp);
-      else memset(&timestamp, 0, sizeof(timestamp));
-
-      //send the report
-      send_report();
-    }
-  for(int j = 0; j < rigids.size(); j++)
-    {
-      if(rigids[j].cond <= 0) continue;
-
-      //set the sensor
-      d_sensor = r2s_map[rigids[j].id];
-      if(slave && d_sensor == 0) {
-        // rigid bodies aren't allowed to be sensor zero in slave mode
-        r2s_map[rigids[j].id] = rigids[j].id;
       }
 
-      //set the position
-      pos[0] = rigids[j].pose[0];
-      pos[1] = rigids[j].pose[1];
-      pos[2] = rigids[j].pose[2];
+    if(pop("type", spec_type))
+      {
+        _error << "required key 'type' not found";
+        return false;
+      }
 
-      //set the orientation quaternion
-      //OWL has the scale factor first, whereas VRPN has it last.
-      d_quat[0] = rigids[j].pose[4];
-      d_quat[1] = rigids[j].pose[5];;
-      d_quat[2] = rigids[j].pose[6];;
-      d_quat[3] = rigids[j].pose[3];;
-
-      // send time out in OWL time
-      if(frequency) frame_to_time(frame, frequency, timestamp);
-      else memset(&timestamp, 0, sizeof(timestamp));
-
-      //send the report
-      send_report();
+    Spec* spec = NULL;
+    if(spec_type == "rigid" || spec_type == "rigid_body")
+      {
+        si.type = OWL::Type::RIGID;
+        spec = spec_rigid;
+      }
+    else if(spec_type == "point")
+      {
+        si.type = OWL::Type::MARKER;
+        spec = spec_marker;
+      }
+    else {
+      _error << "unknown sensor type: " << spec_type;
+      return false;
     }
 
-  return markers.size() || rigids.size() > 0 ? 1 : 0;
+    for(int i = 0; spec[i].dest; i++)
+      {
+        int ret = 0;
+        if(spec[i].type == "string")
+          ret = pop(spec[i].key, *((std::string*) spec[i].dest));
+        else if(spec[i].type == "uint32_t")
+          ret = pop_uint(spec[i].key, *((uint32_t*) spec[i].dest));
+        else if(spec[i].type == "float")
+          ret = pop_float(spec[i].key, *((float*) spec[i].dest));
+        else
+          {
+            _error << "unknown spec type: " << spec[i].type;
+            return false;
+          }
+        if(ret == 1)
+          {
+            if(spec[i].required)
+              {
+                _error << "required key not found: " << spec[i].key;
+                return false;
+              }
+          }
+        else if(ret)
+          {
+            _error << "error reading value for key \'" << spec[i].key << "'";
+            return false;
+          }
+      }
+
+    if(si.type == OWL::Type::RIGID)
+      si.id = si.tracker;
+
+    //special case (legacy)
+    if(!isnan(x) || !isnan(y) || !isnan(z))
+      {
+        if(isnan(x) || isnan(y) || isnan(z))
+          {
+            _error << "x,y,z keys must all be specified if any are specified.";
+            return false;
+          }
+        if(contains("pos"))
+          {
+            _error << "pos and x,y,z keys are mutually exclusive.";
+            return false;
+          }
+        std::stringstream pos; pos << x << ',' << y << ',' << z;
+        keyvals["pos"] = pos.str();
+      }
+
+    si.opt = join();
+    return true;
+  }
+
+  // returns: 0 on success, 1 on key error
+  int pop(std::string key, std::string &val)
+  {
+    if(keyvals.find(key) == keyvals.end())
+      return 1;
+    val = keyvals[key];
+    keyvals.erase(key);
+    return 0;
+  }
+
+  // returns: 0 on success, 1 on key error, 2 on parse error
+  int pop_int(std::string key, int &n)
+  {
+    std::string v;
+    if(pop(key, v)) return 1;
+    return read_int(v.c_str(), n) ? 0 : 2;
+  }
+
+  // returns: 0 on success, 1 on key error, 2 on parse error
+  int pop_uint(std::string key, uint32_t &n)
+  {
+    std::string v;
+    if(pop(key, v)) return 1;
+    return read_uint(v.c_str(), n) ? 0 : 2;
+  }
+
+  // returns: 0 on success, 1 on key error, 2 on parse error
+  int pop_float(std::string key, float &n)
+  {
+    std::string v;
+    if(pop(key, v)) return 1;
+    return read_float(v.c_str(), n) ? 0 : 2;
+  }
+
+  // returns: 0 on success, 1 on key error, 2 on parse error
+  int pop_bool(std::string key, bool &n)
+  {
+    std::string v;
+    if(pop(key, v)) return 1;
+    return read_bool(v.c_str(), n) ? 0 : 2;
+  }
+
+  // return index of error, or -1 on success
+  int parse_kv(std::string str)
+  {
+    keyvals.clear();
+    _error.str("");
+
+    std::vector<char> current_key;
+    std::vector<char> current_val;
+
+    int i = 0;
+    while(str[i])
+      {
+        current_key.clear();
+        current_val.clear();
+        while(isspace(str[i])) i++;
+        while(str[i]) {
+          if(str[i] == '"') {
+            _error << "key names are not allowed to contain quotes or be contained in quotes.";
+            return i;
+          } else if(isspace(str[i])) {
+            _error << "unexpected whitespace.";
+            return i;
+          } else if(str[i] == '=') {
+            i++;
+            break;
+          } else current_key.push_back(str[i++]);
+        }
+        if(!current_key.size()) {
+          _error << "empty key name.";
+          return i;
+        }
+        bool quoted = false;
+        if(str[i] == '"') {
+          quoted = true;
+          i++;
+        }
+        while(str[i]) {
+          if(str[i] == '"') {
+            if(quoted) {
+              quoted = false;
+              i++;
+              break;
+            } else {
+              _error << "misplaced quotes.";
+              return i;
+            }
+          } else if(str[i] == '=') {
+            _error << "unexpected '=' char in value token.";
+            return i;
+          } else if(!quoted && isspace(str[i])) break;
+          else current_val.push_back(str[i++]);
+        }
+        if(quoted) {
+          _error << "unterminated quotes.";
+          return i;
+        }
+        if(str[i] && !isspace(str[i])) {
+          _error << "expected whitespace after value token.";
+          return i;
+        }
+        if(!current_val.size()) {
+          _error << "empty value string.";
+          return i;
+        }
+        std::string key = std::string(current_key.data(), current_key.size());
+        std::string val = std::string(current_val.data(), current_val.size());
+
+        if(keyvals.find(key) != keyvals.end())
+          {
+            _error << "duplicate key encountered: '" << key << "'";
+            return i;
+          }
+        keyvals[key] = val;
+      }
+
+    return -1;
+  }
+};
+
+
+//
+bool vrpn_Tracker_PhaseSpace::load(FILE* file)
+{
+  const int BUFSIZE = 1024;
+  char line[BUFSIZE];
+  bool inTag = false;
+
+  std::string ln;
+  bool eof = false;
+
+  while(!(eof = (fgets(line, BUFSIZE, file) == NULL)))
+    {
+      ConfigParser parser;
+      ln = trim(line, BUFSIZE);
+
+      // skip contentless lines
+      if(!ln.length()) continue;
+
+      // skip lines unless we're nested in <owl> tags
+      if(ln == "<owl>") {
+        if (inTag) {
+          fprintf (stderr, "Error, nested <owl> tag encountered.  Aborting...\n");
+          return false;
+        } else {
+          inTag = true;
+          continue;
+        }
+      } else if (ln == "</owl>") {
+        if (inTag) {
+          if(debug)
+            {
+              printf("parsed config file:\n");
+              printf("    %s\n", options.c_str());
+              for(Sensors::const_iterator s = smgr->begin(); s != smgr->end(); s++)
+                fprintf(stdout, "    sensor=%d type=%d tracker=%d options=\'%s\'\n", s->sensor_id, s->type, s->tracker, s->opt.c_str());
+            }
+          // closing tag encountered,  exit.
+          return true;
+        } else {
+          fprintf (stderr, "Error, </owl> tag without <owl> tag.  Aborting...\n");
+          return false;
+        }
+      }
+
+      // parse line for key-value pairs
+      if(inTag) {
+        int e = parser.parse_kv(ln);
+        if(e >= 0) {
+          fprintf(stderr, "Error at character %d.\n", e);
+          break;
+        }
+      }
+
+      if(parser.contains("sensor")) {
+        // line is a sensor specification
+        SensorInfo info;
+        if(parser.parse(info))
+          {
+            // check duplicates
+            if(smgr->get_by_sensor(info.sensor_id))
+              {
+                fprintf(stderr, "duplicate sensor defined: %d\n", info.sensor_id);
+                break;
+              }
+            smgr->add(info);
+          }
+        else
+          {
+            fprintf(stderr, "%s\n", parser.error().c_str());
+            break;
+          }
+      } else {
+        // line is an option specification
+        if(parser.pop("device", device) == 2)
+          {
+            fprintf(stderr, "error reading value for key 'device'\n");
+            break;
+          }
+        if(parser.pop_bool("drop_frames", drop_frames) == 2)
+          {
+            fprintf(stderr, "error reading value for key 'drop_frames'\n");
+            break;
+          }
+        if(parser.pop_bool("debug", debug) == 2)
+          {
+            fprintf(stderr, "error reading value for key 'debug'\n");
+            break;
+          }
+
+
+        std::string new_options = parser.join();
+        if(new_options.length()) options += (options.length()?" ":"") + parser.join();
+      }
+    }
+
+  if(eof) fprintf(stderr, "Unexpected end of file.\n");
+  else fprintf(stderr, "Unable to parse line: \"%s\"\n", ln.c_str());
+  return false;
 }
+
+
+//
+bool vrpn_Tracker_PhaseSpace::enableStreaming(bool enable)
+{
+  if(!context.isOpen()) return false;
+
+  context.streaming(enable ? 1 : 0);
+  printf("streaming: %d\n", enable);
+
+  if(context.lastError().length())
+    {
+      fprintf(stderr, "owl error: %s\n", context.lastError().c_str());
+      return false;
+    }
+
+  return true;
+}
+
+
+//
+void vrpn_Tracker_PhaseSpace::set_pose(const OWL::Rigid &r)
+{
+  //set the position
+  pos[0] = r.pose[0];
+  pos[1] = r.pose[1];
+  pos[2] = r.pose[2];
+
+  //set the orientation quaternion
+  //OWL has the scale factor first, whereas VRPN has it last.
+  d_quat[0] = r.pose[4];
+  d_quat[1] = r.pose[5];
+  d_quat[2] = r.pose[6];
+  d_quat[3] = r.pose[3];
+}
+
+//
+void vrpn_Tracker_PhaseSpace::report_marker(vrpn_int32 sensor, const OWL::Marker& m)
+{
+  d_sensor = sensor;
+
+  if(debug)
+    {
+      int tr = context.markerInfo(m.id).tracker_id;
+      printf("sensor=%d type=point tracker=%d led=%d x=%f y=%f z=%f cond=%f\n", d_sensor, tr, m.id, m.x, m.y, m.z, m.cond);
+    }
+
+  if(m.cond <= 0) return;
+
+  pos[0] = m.x;
+  pos[1] = m.y;
+  pos[2] = m.z;
+
+  //raw positions have no rotation
+  d_quat[0] = 0;
+  d_quat[1] = 0;
+  d_quat[2] = 0;
+  d_quat[3] = 1;
+
+  send_report();
+}
+
+
+//
+void vrpn_Tracker_PhaseSpace::report_rigid(vrpn_int32 sensor, const OWL::Rigid& r, bool is_stylus)
+{
+  d_sensor = sensor;
+
+  if(debug)
+    {
+  printf("sensor=%d type=rigid tracker=%d x=%f y=%f z=%f w=%f a=%f b=%f c=%f cond=%f\n", d_sensor, r.id, r.pose[0], r.pose[1], r.pose[2], r.pose[3], r.pose[4], r.pose[5], r.pose[6], r.cond);
+    }
+
+  if(r.cond <= 0) return;
+
+  // set the position/orientation
+  set_pose(r);
+  send_report();
+}
+
 
 //
 void vrpn_Tracker_PhaseSpace::send_report(void)
 {
   if(d_connection)
     {
-      char	msgbuf[VRPN_PHASESPACE_MSGBUFSIZE];
-      int	len = encode_to(msgbuf);
-      if(d_connection->pack_message(len, timestamp, position_m_id, d_sender_id, msgbuf,
+      char	msgbuf[MSGBUFSIZE];
+      int	len = vrpn_Tracker::encode_to(msgbuf);
+      if(d_connection->pack_message(len, vrpn_Tracker::timestamp, position_m_id, d_sender_id, msgbuf,
                                     vrpn_CONNECTION_LOW_LATENCY)) {
         fprintf(stderr,"PhaseSpace: cannot write message: tossing\n");
       }
     }
 }
 
+
 //
-void vrpn_Tracker_PhaseSpace::setFrequency(float freq)
+void vrpn_Tracker_PhaseSpace::report_button(vrpn_int32 sensor, int value)
 {
-#ifdef DEBUG
-  printf("%s %f\n", __PRETTY_FUNCTION__, freq);
-#endif
-  if(freq < 0 || freq > OWL_MAX_FREQUENCY) {
-    fprintf(stderr,"Error:  Invalid frequency requested, defaulting to %f hz\n", OWL_MAX_FREQUENCY);
-    freq = OWL_MAX_FREQUENCY;
-  }
+  if(d_sensor < 0 || d_sensor >= vrpn_BUTTON_MAX_BUTTONS)
+    {
+      fprintf(stderr, "error: sensor %d exceeds max button count\n", sensor);
+      return;
+    }
 
-  frequency = freq;
+  d_sensor = sensor;
+  buttons[d_sensor] = value;
 
-  if(owlRunning) {
-    float tmp = -1;
-    owlSetFloat(OWL_FREQUENCY, frequency);
-    owlGetFloatv(OWL_FREQUENCY, &tmp);
-    if(!owlGetStatus() || tmp == -1)
-      fprintf(stderr,"Error: unable to set frequency\n");
-  }
-  return;
+  if(debug)
+    {
+      printf("button %d 0x%x\n", d_sensor, value);
+    }
 }
+
+
+//
+void vrpn_Tracker_PhaseSpace::report_button_analog(vrpn_int32 sensor, int value)
+{
+  d_sensor = sensor;
+  setChannelValue(d_sensor, value);
+
+  if(debug)
+    {
+      printf("analog button %d 0x%x\n", d_sensor, value);
+    }
+}
+
+
+//
+template<class A>
+const A* find(int id, size_t& hint, std::vector<A> &data)
+{
+  if(hint >= data.size() || id != data[hint].id)
+    {
+      for(size_t i = 0; i < data.size(); i++)
+        {
+          const A &d = data[i];
+          if(d.id == id)
+            {
+              hint = i;
+              return &d;
+            }
+        }
+      return NULL;
+    }
+  return &data[hint];
+}
+
+//
+int vrpn_Tracker_PhaseSpace::get_report(void)
+{
+  if(!context.isOpen()) return 0;
+
+  int maxiter = 1;
+
+  // set limit on looping
+  if(drop_frames) maxiter = 10000;
+
+  // read new data
+  const OWL::Event *event = NULL;
+
+  {
+    const OWL::Event *e = NULL;;
+    int count = 0;
+    while(context.isOpen() && context.property<int>("initialized") && (e = context.nextEvent()))
+      {
+        if(e->type_id() == OWL::Type::FRAME) event = e;
+        else if(e->type_id() == OWL::Type::ERROR)
+          {
+            std::string err;
+            e->get(err);
+            fprintf(stderr, "owl error event: %s\n", err.c_str());
+            context.done();
+            context.close();
+            return -1;
+          }
+        else if(e->type_id() == OWL::Type::BYTE)
+          {
+            std::string s; e->get(s);
+            printf("%s: %s\n", e->name(), s.c_str());
+
+            if(strcmp(e->name(), "done") == 0)
+              return 0;
+          }
+        if(maxiter && ++count >= maxiter) break;
+      }
+  }
+
+  if(!event) return 0;
+
+  // set timestamp
+#if WIN32 // msvc 2008
+  vrpn_Tracker::timestamp.tv_sec = (long) event->time() / 1000000;
+  vrpn_Tracker::timestamp.tv_sec = (long) event->time() % 1000000;
+#else
+  lldiv_t divresult = lldiv(event->time(), 1000000);
+  vrpn_Tracker::timestamp.tv_sec = divresult.quot;
+  vrpn_Tracker::timestamp.tv_usec = divresult.rem;
+#endif
+
+  if(debug)
+    {
+      printf("time=%ld.%06ld\n", vrpn_Tracker::timestamp.tv_sec, vrpn_Tracker::timestamp.tv_usec);
+    }
+
+  OWL::Markers markers;
+  OWL::Rigids rigids;
+
+  for(const OWL::Event *e = event->begin(); e != event->end(); e++)
+    {
+      if(e->type_id() == OWL::Type::MARKER)
+        e->get(markers);
+      else if(e->type_id() == OWL::Type::RIGID)
+        e->get(rigids);
+    }
+
+  int slave = context.property<int>("slave");
+  std::vector<const OWL::Marker*> reported_markers;
+  std::vector<const OWL::Rigid*> reported_rigids;
+  int sensor = 0;
+
+  for(Sensors::iterator s = smgr->begin(); s != smgr->end(); s++)
+    {
+      switch(s->type)
+        {
+        case OWL::Type::MARKER:
+          {
+            const OWL::Marker *m = find<OWL::Marker>(s->id, s->search_hint, markers);
+            if(m) {
+              report_marker(s->sensor_id, *m);
+              if(slave) reported_markers.push_back(m);
+            }
+          }
+          break;
+        case OWL::Type::RIGID:
+          {
+            const OWL::Rigid *r = find<OWL::Rigid>(s->id, s->search_hint, rigids);
+            if(r) {
+              report_rigid(s->sensor_id, *r);
+              if(slave) reported_rigids.push_back(r);
+            }
+          }
+          break;
+        default:
+          break;
+        }
+
+      // TODO implement styluses
+
+      if(s->sensor_id > sensor) sensor = s->sensor_id;
+    }
+
+  if(slave)
+    {
+      // in slave mode, client doesn't necessarily know what the incoming data will be.
+      // Report the ones not specified in the cfg file
+      if(sensor < 1000) sensor = 1000; // start arbitrarily at 1000
+      for(OWL::Markers::iterator m = markers.begin(); m != markers.end(); m++)
+        if(std::find(reported_markers.begin(), reported_markers.end(), &*m) == reported_markers.end())
+          report_marker(sensor++, *m);
+      for(OWL::Rigids::iterator r = rigids.begin(); r != rigids.end(); r++)
+        if(std::find(reported_rigids.begin(), reported_rigids.end(), &*r) == reported_rigids.end())
+          report_rigid(sensor++, *r);
+    }
+
+  // finalize button and analog reports
+  vrpn_Button_Filter::report_changes();
+  vrpn_Clipping_Analog_Server::report_changes();
+
+  if(context.lastError().length())
+    {
+      printf("owl error: %s\n", context.lastError().c_str());
+      return -1;
+    }
+
+  if(!context.property<int>("initialized"))
+    return -1;
+
+  return (markers.size() || rigids.size()) ? 1 : 0;
+}
+
 
 //
 int vrpn_Tracker_PhaseSpace::handle_update_rate_request(void *userdata, vrpn_HANDLERPARAM p)
 {
-#ifdef DEBUG
-  printf("%s\n", __PRETTY_FUNCTION__);
-#endif
   vrpn_Tracker_PhaseSpace* thistracker = (vrpn_Tracker_PhaseSpace*)userdata;
+  if(thistracker->debug) {
+    printf("vrpn_Tracker_PhaseSpace::handle_update_rate_request\n");
+  }
   vrpn_float64 update_rate = 0;
   vrpn_unbuffer(&p.buffer,&update_rate);
-  thistracker->setFrequency((float) update_rate);
+  thistracker->context.frequency((float) update_rate);
   return 0;
 }
 
-#endif
+#endif // VRPN_INCLUDE_PHASESPACE


### PR DESCRIPTION
…is still requires a libowlsock.{dll,so} provided by PhaseSpace,  but the API has changed dramatically from major version 4.

Changes tested against libowlsock version 5.1.310.

Removed support for libowlsock major version 4 and below.

server_src/vrpn.cfg:  Changed phasespace configuration syntax and updated documentation.