### PR TITLE
Adding a parameter to the constructor for a DTrack that was read from…

### DIFF
--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -2943,7 +2943,7 @@ int vrpn_Generic_Server_Object::setup_DTrack(char *&pch, char *line,
 
     _devices->add(new vrpn_Tracker_DTrack(s2, connection, dtrackPort,
                                           timeToReachJoy, nob, nof, pidbf,
-                                          actTracing));
+                                          act3DOFout, actTracing));
 
     return 0;
 #else


### PR DESCRIPTION
… the config file but not passed in.

Fix in response to a bug report.