### PR TITLE
set default poll rates

### DIFF
--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -2494,13 +2494,22 @@
 # (Need a description of how to run this and an example commented-out line.)
 
 ###############################################################################
-# $Header: /PDIvrpn.root/2.0.0/PDIVRPN/vrpn_G4.cfg 1     6/05/12 12:23p Ben $
+# To access Polhemus G4 on Windows using the Polhemus PDI library,
+# use vrpn_Tracker_G4.
 #
-# The command for a G4 requires the tracker name, the server name for the
-# tracker, and on the next line, the file path to the .g4c configuration file:
+# The vrpn_Tracker_G4 tracker definition requires the tracker name and 
+# the vrpn server name for the tracker, followed by an optional Server Poll rate,
+# and on the next line, the file path to the .g4c configuration file:
 #
 # vrpn_Tracker_G4 G4 \
 # C:\filepath\source_config_file.g4c
+#
+# The Server Poll Rate is optional.  
+# If it is not specified, the VRPN server will poll for new data at a rate of 120 frames per second.  
+# (120 frames per second is the default output rate of G4 hardware.)
+#
+# If you wish to poll at a slower rate than the tracker, you may specify any number.  For example, if
+#   you wish to poll 20 times per second, then specify a poll rate of 20.  
 #
 # The '\' at the end of the first line, after the server name, is optional and
 # will be disregarded.  A '\' on a subsequent line means that further commands
@@ -2728,10 +2737,33 @@
 # N2,*,*
 
 ###############################################################################
-# The command for a FastrakPDI requires the tracker name, and the server name for the tracker:
+# To access Polhemus FasTrak on Windows using the Polhemus PDI library,
+# use vrpn_Tracker_FastrakPDI.
 #
-# vrpn_Tracker_FastrakPDI Fastrak\       <-valid
-# vrpn_Tracker_FastrakPDI Highpoint\     <-valid
+# The vrpn_Tracker_FastrakPDI tracker definition requires the tracker name and 
+# the vrpn server name for the tracker, followed by an optional Server Poll rate:
+#
+# vrpn_Tracker_FastrakPDI myFastrak4   30\       <-valid
+# vrpn_Tracker_FastrakPDI myFastrak2   60\       <-valid
+# vrpn_Tracker_FastrakPDI myFastrak1     \       <-valid
+#
+# The Server Poll Rate is optional.  
+# If it is not specified, the VRPN server will poll for new data at a rate of 120 frames per second.  
+# (120 frames per second is the default output rate of FasTrak hardware with ONE sensor connected.)
+# 
+# For FasTrak trackers the update rate depends on the number of sensors connected to the device:
+#   Number of Sensors         Update Rate
+#   -----------------         -----------
+#         1                       120 frames/sec
+#         2                        60 frames/sec  
+#         3                        40 frames/sec
+#         4                        30 frames/sec
+#
+# If you wish to poll at the same rate as the tracker output, then you must specify the poll rate 
+#   to match the update rate in the table above.
+#
+# If you wish to poll at a slower rate than the tracker, you may specify any number.  For example, if
+#   you wish to poll 20 times per second, then specify and update rate of 20.  
 #
 # The '\' at the end of the first line, after the server name, is optional and will be disregarded.
 #   a '\' on a subsequent line means that further commands are to be input. The format is to have
@@ -2804,8 +2836,9 @@
 # -collects a second single pno to confirm this removal (P) and
 # -finally returns to binary mode before passing control to VRPN (F1<>).
 # The trackers name is TrackerJoe.
+# The server poll rate is 120 Hz.   
 
-# vrpn_Tracker_FastrakPDI	TrackerJoe\
+# vrpn_Tracker_FastrakPDI	TrackerJoe    120\
 # PDIStylus 1\
 # F\
 # G1,0,0,0<>\
@@ -2817,17 +2850,33 @@
 
 #------------------------------------------------------------------------------
 # The default config is below.
+# -Assumes that one sensor is connected to FasTrak, and polls at 120 Hz
 
-# vrpn_Tracker_FastrakPDI Blueberry
+# vrpn_Tracker_FastrakPDI myFasTrak
 
 ###############################################################################
-# The command for a LibertyPDI or PatriotPDI requires the tracker name, and the server name for the tracker:
+# To access Polhemus Liberty or Patriot on Windows using the Polhemus PDI library,
+# use vrpn_Tracker_LibertyPDI.
 #
-# vrpn_Tracker_LibertyPDI Liberty\       <-valid
-# vrpn_Tracker_LibertyPDI Patriot\       <-valid
-# vrpn_Tracker_LibertyPDI BriansTracker\ <-valid
-# vrpn_Tracker_PatriotPDI Patriot\       <-Not valid.  Use vrpn_Tracker_LibertyPDI for patriot and liberty
+# The vrpn_Tracker_LibertyPDI tracker definition requires the tracker name and 
+# the vrpn server name for the tracker, followed by an optional Server Poll rate:
 #
+# vrpn_Tracker_LibertyPDI MyLiberty        240\       <-valid
+# vrpn_Tracker_LibertyPDI MyPatriot           \       <-valid
+# vrpn_Tracker_LibertyPDI MyPolhemus       120\         <-valid
+#
+# Note that "Tracker_LibertyPDI" is used for both Polhemus Patriot and Liberty tracker hardware!
+#
+# The Server Poll Rate is optional.  
+# If it is not specified, the VRPN server will poll for new data at a rate of 60 frames per second.  
+# (60 frames per second is the default output rate of Patriot tracker hardware.)
+# 
+# For Liberty trackers, the default rate is 240 frames per second.  If you wish for the server to poll
+#   at this rate, then you must specify 240!
+#
+# If you wish to poll at a slower rate than the tracker, you may specify any number.  For example, if
+#   you wish to poll 20 times per second, then specify and update rate of 20.  
+# 
 # The '\' at the end of the first line, after the server name, is optional and will be disregarded.
 #   a '\' on a subsequent line means that further commands are to be input. The format is to have
 #   one command per line.  Each line that isn't the final line must end in a '\'.  The final line should not
@@ -2844,6 +2893,10 @@
 #   these settings by requesting a single frame in ASCII mode with the command P (note, P requires no <>).
 #   Read the patriot or liberty manual for a full list of commands.
 #
+#   Note: The R command is used to set the Liberty tracker update rate.  This command has no effect on Patriot.
+#     For Liberty, if you use the R command to change the update rate, remember to change the Server Poll Rate
+#     specification in the tracker definition (like "MyPolhemus" example above).  
+
 # Command Syntax:
 #   Every command, except P (gather single pno frame), requires a carriage return on the end.  Carriage
 #   returns are represented by '<>'.  Control commands, noted as ^X (where X is any capitol letter) in the
@@ -2888,7 +2941,7 @@
 #          button object can be created per stylus.
 #
 #------------------------------------------------------------------------------
-# The following example config:
+# The following example config for a Liberty tracker:
 # -specifies that stations 1 and 2 are Polhemus Stylus Devices
 # -sets the tracker to ASCII responses (F0<>),
 # -sends the tracker a whoami (^V<>),
@@ -2898,9 +2951,10 @@
 # -collects a second single pno to confirm (P),
 # -enters an invalid command to demonstrate the advantage of ASCII mode (^ZX<>) and finally,
 # -most importantly, returns to binary mode before passing control to VRPN (F1<>).
-# The tracker server name is TrackerJohn.
+# The tracker server name is myLiberty.
+# The server poll rate is 240 Hz
 #
-# vrpn_Tracker_LibertyPDI	TrackerJohn\
+# vrpn_Tracker_LibertyPDI	myLiberty  240\
 # PDIStylus 1\
 # PDIStylus 2\
 # F0<>\
@@ -2913,10 +2967,15 @@
 # F1<>
 #
 #-----------------------------------------------------------------------------
-# Finally the default config is below.
+# Finally the default config below:
+# -May be used for a Liberty or a Patriot tracker
+# -Polls the tracker 60 times per second 
+# -Sets tracker output to ASCII
+# -Queries the tracker for WhoAmI information
+# -Sets the output back to Binary
 ##############################################################################
 
-# vrpn_Tracker_LibertyPDI Strawberry\
+# vrpn_Tracker_LibertyPDI defaultPolhemus\
 # F0<>\
 # ^V<>\
 # F1<>

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -4271,7 +4271,7 @@ int vrpn_Generic_Server_Object::setup_Tracker_G4(char *&pch, char *line,
 {
     char name[LINESIZE], filepath[LINESIZE];
     int numparms;
-    int Hz = 10;
+    int Hz = 120;
 
     VRPN_CONFIG_NEXT();
     // Get the arguments (class, tracker_name)
@@ -4392,7 +4392,7 @@ int vrpn_Generic_Server_Object::setup_Tracker_FastrakPDI(char *&pch, char *line,
                                                          FILE *config_file)
 {
     char name[LINESIZE];
-    int Hz = 10;
+    int Hz = 120;
     char rcmd[5000]; // reset commands to send to Liberty
     unsigned int nStylusMap = 0;
     VRPN_CONFIG_NEXT();
@@ -4465,7 +4465,7 @@ int vrpn_Generic_Server_Object::setup_Tracker_LibertyPDI(char *&pch, char *line,
                                                          FILE *config_file)
 {
     char name[LINESIZE];
-    int Hz = 10;
+    int Hz = 60;
     unsigned int nStylusMap = 0;
     char rcmd[5000]; // reset commands to send to Liberty
 


### PR DESCRIPTION
Set default server poll rates for Polhemus vrpn_Tracker_G4, vrpn_Tracker_FasTrakPDI, and vrpn_Tracker_LibertyPDI.

Documented poll rate specification in server_src/vrpn.cfg file instructions.