### PR TITLE
CMake: Allow custom sysconfdir for installation. Fixes #185

### DIFF
--- a/server_src/CMakeLists.txt
+++ b/server_src/CMakeLists.txt
@@ -138,6 +138,10 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/vrpn.cfg"
 	"${CMAKE_CURRENT_BINARY_DIR}/vrpn.cfg"
 	@ONLY)
 
+if(NOT SYSCONF_INSTALL_DIR)
+	set(SYSCONF_INSTALL_DIR etc)
+endif(NOT SYSCONF_INSTALL_DIR)
+
 if(VRPN_INSTALL)
 	if(WIN32)
 		install(FILES "${CMAKE_CURRENT_BINARY_DIR}/vrpn.cfg"
@@ -145,7 +149,7 @@ if(VRPN_INSTALL)
 			COMPONENT mainserver)
 	else()
 		install(FILES "${CMAKE_CURRENT_BINARY_DIR}/vrpn.cfg"
-			DESTINATION etc
+			DESTINATION ${SYSCONF_INSTALL_DIR}
 			COMPONENT mainserver)
 	endif()
 


### PR DESCRIPTION
Now you can set a custom `sysconfdir` for the installation of  `vrpn.cfg`.
Before this, the configuration was installed into /usr/etc if you set `CMAKE_INSTALL_PREFIX` to `/usr` (as commonly done by distribution packagers).