### PR TITLE
SpacePoint fixes

### DIFF
--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -2293,10 +2293,13 @@
 
 ################################################################################
 # PNI SpacePoint Fusion 3DOF rotation tracker
-# Reports 1 sensor as quaternion
+# Reports 1 sensor as quaternion.
+# The device index can be specified in order to open multiple identical devices,
+# if not specified, 0 is assumed.
 #   char    name_of_this_device[]
+#   [int    device index]
 
-#vrpn_Tracker_SpacePoint SpacePoint0
+#vrpn_Tracker_SpacePoint SpacePoint0 0
 
 ################################################################################
 # 5DT DataGlove "Ultra" USB/USB Wireless support (based on HID)

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -3755,23 +3755,25 @@ int vrpn_Generic_Server_Object::setup_SpacePoint(char *&pch, char *line,
 {
 
     char s2[LINESIZE];
+    int idx = 0;
 
     VRPN_CONFIG_NEXT();
 
-    if (sscanf(pch, "%511s", s2) != 1) {
+    if (sscanf(pch, "%511s%d", s2, &idx) < 1) {
         fprintf(stderr, "Bad SpacePoint line: %s\n", line);
         return -1;
     }
+
 
 // Open the SpacePoint
 
 #ifdef VRPN_USE_HID
     // Open the tracker
     if (verbose) {
-        printf("Opening vrpn_Tracker_SpacePoint %s\n", s2);
+        printf("Opening vrpn_Tracker_SpacePoint #%d %s\n", idx, s2);
     }
 
-    _devices->add(new vrpn_Tracker_SpacePoint(s2, connection));
+    _devices->add(new vrpn_Tracker_SpacePoint(s2, connection, idx));
 #else
     fprintf(stderr,
             "SpacePoint driver works only with VRPN_USE_HID defined!\n");

--- a/vrpn_HumanInterface.C
+++ b/vrpn_HumanInterface.C
@@ -168,6 +168,7 @@ bool vrpn_HidInterface::reconnect()
         device_info.manufacturer_string = loop->manufacturer_string;
         device_info.product_string = loop->product_string;
         device_info.interface_number = loop->interface_number;
+        device_info.path = loop->path;
         // printf("XXX Found vendor 0x%x, product 0x%x, interface %d\n",
         // (unsigned)(loop->vendor_id), (unsigned)(loop->product_id),
         // (int)(loop->interface_number) );

--- a/vrpn_HumanInterface.h
+++ b/vrpn_HumanInterface.h
@@ -44,6 +44,7 @@ struct vrpn_HIDDEVINFO {
     wchar_t *manufacturer_string;
     wchar_t *product_string;
     int interface_number;
+    const char *path;
 };
 
 // General interface for device enumeration:

--- a/vrpn_Tracker_SpacePoint.C
+++ b/vrpn_Tracker_SpacePoint.C
@@ -7,6 +7,7 @@
 
 #include <stdio.h>                      // for fprintf, stderr
 #include <string.h>                     // for memset
+#include <string>
 #include <set>
 
 #include "vrpn_Connection.h"            // for vrpn_CONNECTION_LOW_LATENCY, etc
@@ -56,7 +57,7 @@ public:
            (m_accepted_already.size() == m_index) &&
            (m_accepted_already.find(device.path) == m_accepted_already.end()))
         {
-            m_accepted_already.emplace(device.path);
+            m_accepted_already.insert(device.path);
             return true;
         }
         else
@@ -71,7 +72,6 @@ public:
 
 private:
     unsigned m_index;
-    unsigned m_found;
     static std::set<std::string> m_accepted_already;
 };
 

--- a/vrpn_Tracker_SpacePoint.C
+++ b/vrpn_Tracker_SpacePoint.C
@@ -7,6 +7,7 @@
 
 #include <stdio.h>                      // for fprintf, stderr
 #include <string.h>                     // for memset
+#include <set>
 
 #include "vrpn_Connection.h"            // for vrpn_CONNECTION_LOW_LATENCY, etc
 #include "vrpn_Tracker_SpacePoint.h"
@@ -17,10 +18,70 @@ const unsigned SPACEPOINT_PRODUCT = 0x0100;
 VRPN_SUPPRESS_EMPTY_OBJECT_WARNING()
 
 #ifdef VRPN_USE_HID
-vrpn_Tracker_SpacePoint::vrpn_Tracker_SpacePoint(const char * name, vrpn_Connection * trackercon) :
-                    vrpn_Tracker(name, trackercon), vrpn_Button(name, trackercon),
-                    vrpn_HidInterface(new vrpn_HidProductAcceptor(SPACEPOINT_VENDOR, SPACEPOINT_PRODUCT),
-                    SPACEPOINT_VENDOR, SPACEPOINT_PRODUCT)
+
+/*
+ * Hackish acceptor to work around the broken Windows 10 behavior
+ * where devices are opened in shared mode by default. That prevents
+ * using opening failure to detect an already-in-use device and thus
+ * it is impossible to instantiate multiple copies of this driver for
+ * multiple sensors (they will all read from the first accepted
+ * device).
+ *
+ * This acceptor works it around by keeping a track of already
+ * accepted devices and forcing the use of the next device when
+ * attempting to accept an already accepted one.
+ *
+ * BUGS: the reset() method is useless - we need the device set be
+ * persistent between instantiations of this acceptor and the reset
+ * gets called at the start by all constructors of vrpn_HidInterface :(
+ */
+
+class SpacePointAcceptor : public vrpn_HidAcceptor {
+public:
+    SpacePointAcceptor(unsigned index)
+        : m_index(index)
+    {}
+
+    virtual ~SpacePointAcceptor()
+    {}
+
+    bool accept(const vrpn_HIDDEVINFO &device)
+    {
+        // device.interface_number - SpacePoint clones have only
+        // a single interface and report -1 there, genuine PNI SpacePoint has 2 interfaces
+        // a we need the device with iface num 1 (0 is the raw sensor interface)
+        if((device.vendor == SPACEPOINT_VENDOR) &&
+           (device.product == SPACEPOINT_PRODUCT) &&
+           (device.interface_number < 0 || device.interface_number == 1) &&
+           (m_accepted_already.size() == m_index) &&
+           (m_accepted_already.find(device.path) == m_accepted_already.end()))
+        {
+            m_accepted_already.emplace(device.path);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    void reset()
+    {
+        // disabled, see comment above
+        // m_accepted_already.clear();
+    }
+
+private:
+    unsigned m_index;
+    unsigned m_found;
+    static std::set<std::string> m_accepted_already;
+};
+
+std::set<std::string> SpacePointAcceptor::m_accepted_already;
+
+//new vrpn_HidNthMatchAcceptor(index, new vrpn_HidProductAcceptor(SPACEPOINT_VENDOR, SPACEPOINT_PRODUCT))
+vrpn_Tracker_SpacePoint::vrpn_Tracker_SpacePoint(const char * name, vrpn_Connection * trackercon, int index)
+    : vrpn_Tracker(name, trackercon)
+    , vrpn_Button(name, trackercon)
+    , vrpn_HidInterface(new SpacePointAcceptor(index), SPACEPOINT_VENDOR, SPACEPOINT_PRODUCT)
 {
     memset(d_quat, 0, 4 * sizeof(float));
     d_quat[3] = 1.0;

--- a/vrpn_Tracker_SpacePoint.h
+++ b/vrpn_Tracker_SpacePoint.h
@@ -24,7 +24,7 @@ class VRPN_API vrpn_Connection;
 class VRPN_API vrpn_Tracker_SpacePoint: public vrpn_Tracker, vrpn_Button, vrpn_HidInterface
 {
     public:
-        vrpn_Tracker_SpacePoint(const char * name, vrpn_Connection * trackercon);
+        vrpn_Tracker_SpacePoint(const char * name, vrpn_Connection * trackercon, int index = 0);
 
         virtual void mainloop ();
 


### PR DESCRIPTION
Hello, 

This PR fixes broken SpacePoint enumeration in Windows 10 (yay for opening devices with sharing enable by default!). 

In addition, it adds support for multiple SpacePoints. This required addition of the device path to the vrpn_HIDDEVINFO struct because with the non-exclusive open issue above it is impossible to differentiate among the identical devices in the acceptor (cannot rely on the already in-use device failing to open anymore). 

As a side-effect it also fixes a segfault with the SpacePoint in Linux - the vrpn_HidInterface code ignores that the devices has failed to open and attempts to read from a null pointer -> crash. 

Thanks,

Jan
