### PR TITLE
Fix Android build: NDK-supplied toolchain file lacks find_host_*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,7 @@ option_requires(VRPN_BUILD_PYTHON_HANDCODED_3X
 ###
 # javac, jar, and javah (for java wrapper)
 ###
-if(ANDROID)
+if(ANDROID AND DEFINED find_host_package)
 	find_host_package(Java COMPONENTS Development)
 	find_host_package(JNI)
 	find_host_program(JAVAH_EXECUTABLE NAMES javah)


### PR DESCRIPTION
The android.toolchain.cmake file that comes with the most recent NDK distributions lacks a definition for `find_host_package` and friends. This just adds an extra condition so that the build succeeds.