### PR TITLE
DevInput: Fix string corruption and behavior in systems with multiple entries per device

### DIFF
--- a/vrpn_DevInput.C
+++ b/vrpn_DevInput.C
@@ -31,7 +31,7 @@ VRPN_SUPPRESS_EMPTY_OBJECT_WARNING()
 
 static const std::string EMPTY_STRING("");
 
-static const std::string &getDeviceNodes(const std::string &device_name)
+static const std::string getDeviceNodes(const std::string &device_name)
 {
   std::map<std::string, std::string> s_devicesNodes;
 
@@ -44,7 +44,8 @@ static const std::string &getDeviceNodes(const std::string &device_name)
     int fd = open(oss.str().c_str(), O_RDONLY);
     if(fd >= 0){
       char name[512];
-      if(ioctl(fd, EVIOCGNAME(sizeof(name)), name) >= 0) {
+      if((ioctl(fd, EVIOCGNAME(sizeof(name)), name) >= 0)
+          && (s_devicesNodes.find(name) == s_devicesNodes.end())) {
         s_devicesNodes[name] = oss.str();
       }
 


### PR DESCRIPTION
We no longer return a reference to a local variable. Also, we now
only add entries to the device map if the device has been seen
before.