### PR TITLE
Removing return value from all but string-reading vrpn_unbuffer() cal…

### DIFF
--- a/vrpn_BaseClass.C
+++ b/vrpn_BaseClass.C
@@ -539,9 +539,7 @@ int vrpn_BaseClassUnique::decode_text_message_from_buffer(
     *severity = (vrpn_TEXT_SEVERITY)(severity_as_uint);
     vrpn_unbuffer(&bufptr, level);
     // Negative length means "unpack until NULL"
-    if (vrpn_unbuffer(&bufptr, msg, -(int)(vrpn_MAX_TEXT_LEN)) != 0) {
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, msg, -(int)(vrpn_MAX_TEXT_LEN));
 
     return 0;
 }

--- a/vrpn_ForceDevice.C
+++ b/vrpn_ForceDevice.C
@@ -21,9 +21,6 @@
 enum TrimeshType { GHOST, HCOLLIDE };
 #endif
 
-#define CHECK(a)                                                               \
-    if (a == -1) return -1
-
 #if 0
 // c = a x b
 static void vector_cross (const vrpn_float64 a [3], const vrpn_float64 b [3],
@@ -248,7 +245,7 @@ vrpn_int32 vrpn_ForceDevice::decode_force(const char *buffer,
     }
 
     for (i = 0; i < 3; i++)
-        CHECK(vrpn_unbuffer(&mptr, &(force[i])));
+        (vrpn_unbuffer(&mptr, &(force[i])));
 
     return 0;
 }
@@ -299,8 +296,8 @@ vrpn_int32 vrpn_ForceDevice::decode_custom_effect(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, effectId));
-    CHECK(vrpn_unbuffer(&mptr, nbParams));
+    (vrpn_unbuffer(&mptr, effectId));
+    (vrpn_unbuffer(&mptr, nbParams));
 
     if ((vrpn_uint32)(len) <
         (2 * sizeof(vrpn_uint32) + (*nbParams) * sizeof(vrpn_float32))) {
@@ -320,7 +317,7 @@ vrpn_int32 vrpn_ForceDevice::decode_custom_effect(const char *buffer,
     }
 
     for (vrpn_uint32 i = 0; i < (*nbParams); i++) {
-        CHECK(vrpn_unbuffer(&mptr, &((*params)[i])));
+        (vrpn_unbuffer(&mptr, &((*params)[i])));
     }
 
     return 0;
@@ -370,9 +367,9 @@ vrpn_int32 vrpn_ForceDevice::decode_scp(const char *buffer,
     }
 
     for (i = 0; i < 3; i++)
-        CHECK(vrpn_unbuffer(&mptr, &(pos[i])));
+        (vrpn_unbuffer(&mptr, &(pos[i])));
     for (i = 0; i < 4; i++)
-        CHECK(vrpn_unbuffer(&mptr, &(quat[i])));
+        (vrpn_unbuffer(&mptr, &(quat[i])));
 
     return 0;
 }
@@ -430,13 +427,13 @@ vrpn_int32 vrpn_ForceDevice::decode_plane(
     }
 
     for (i = 0; i < 4; i++)
-        CHECK(vrpn_unbuffer(&mptr, &(plane[i])));
-    CHECK(vrpn_unbuffer(&mptr, kspring));
-    CHECK(vrpn_unbuffer(&mptr, kdamp));
-    CHECK(vrpn_unbuffer(&mptr, fdyn));
-    CHECK(vrpn_unbuffer(&mptr, fstat));
-    CHECK(vrpn_unbuffer(&mptr, plane_index));
-    CHECK(vrpn_unbuffer(&mptr, n_rec_cycles));
+        (vrpn_unbuffer(&mptr, &(plane[i])));
+    (vrpn_unbuffer(&mptr, kspring));
+    (vrpn_unbuffer(&mptr, kdamp));
+    (vrpn_unbuffer(&mptr, fdyn));
+    (vrpn_unbuffer(&mptr, fstat));
+    (vrpn_unbuffer(&mptr, plane_index));
+    (vrpn_unbuffer(&mptr, n_rec_cycles));
 
     return 0;
 }
@@ -487,12 +484,12 @@ vrpn_int32 vrpn_ForceDevice::decode_surface_effects(
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, k_adhesion_normal));
-    CHECK(vrpn_unbuffer(&mptr, k_adhesion_lateral));
-    CHECK(vrpn_unbuffer(&mptr, tex_amp));
-    CHECK(vrpn_unbuffer(&mptr, tex_wl));
-    CHECK(vrpn_unbuffer(&mptr, buzz_amp));
-    CHECK(vrpn_unbuffer(&mptr, buzz_freq));
+    (vrpn_unbuffer(&mptr, k_adhesion_normal));
+    (vrpn_unbuffer(&mptr, k_adhesion_lateral));
+    (vrpn_unbuffer(&mptr, tex_amp));
+    (vrpn_unbuffer(&mptr, tex_wl));
+    (vrpn_unbuffer(&mptr, buzz_amp));
+    (vrpn_unbuffer(&mptr, buzz_freq));
 
     return 0;
 }
@@ -543,11 +540,11 @@ vrpn_int32 vrpn_ForceDevice::decode_vertex(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, vertNum));
-    CHECK(vrpn_unbuffer(&mptr, x));
-    CHECK(vrpn_unbuffer(&mptr, y));
-    CHECK(vrpn_unbuffer(&mptr, z));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, vertNum));
+    (vrpn_unbuffer(&mptr, x));
+    (vrpn_unbuffer(&mptr, y));
+    (vrpn_unbuffer(&mptr, z));
 
     return 0;
 }
@@ -600,11 +597,11 @@ vrpn_int32 vrpn_ForceDevice::decode_normal(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, vertNum));
-    CHECK(vrpn_unbuffer(&mptr, x));
-    CHECK(vrpn_unbuffer(&mptr, y));
-    CHECK(vrpn_unbuffer(&mptr, z));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, vertNum));
+    (vrpn_unbuffer(&mptr, x));
+    (vrpn_unbuffer(&mptr, y));
+    (vrpn_unbuffer(&mptr, z));
 
     return 0;
 }
@@ -654,14 +651,14 @@ vrpn_int32 vrpn_ForceDevice::decode_triangle(
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, triNum));
-    CHECK(vrpn_unbuffer(&mptr, vert0));
-    CHECK(vrpn_unbuffer(&mptr, vert1));
-    CHECK(vrpn_unbuffer(&mptr, vert2));
-    CHECK(vrpn_unbuffer(&mptr, norm0));
-    CHECK(vrpn_unbuffer(&mptr, norm1));
-    CHECK(vrpn_unbuffer(&mptr, norm2));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, triNum));
+    (vrpn_unbuffer(&mptr, vert0));
+    (vrpn_unbuffer(&mptr, vert1));
+    (vrpn_unbuffer(&mptr, vert2));
+    (vrpn_unbuffer(&mptr, norm0));
+    (vrpn_unbuffer(&mptr, norm1));
+    (vrpn_unbuffer(&mptr, norm2));
 
     return 0;
 }
@@ -705,8 +702,8 @@ vrpn_int32 vrpn_ForceDevice::decode_removeTriangle(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, triNum));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, triNum));
 
     return 0;
 }
@@ -755,11 +752,11 @@ vrpn_int32 vrpn_ForceDevice::decode_updateTrimeshChanges(
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, kspring));
-    CHECK(vrpn_unbuffer(&mptr, kdamp));
-    CHECK(vrpn_unbuffer(&mptr, fstat));
-    CHECK(vrpn_unbuffer(&mptr, fdyn));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, kspring));
+    (vrpn_unbuffer(&mptr, kdamp));
+    (vrpn_unbuffer(&mptr, fstat));
+    (vrpn_unbuffer(&mptr, fdyn));
 
     return 0;
 }
@@ -804,8 +801,8 @@ vrpn_int32 vrpn_ForceDevice::decode_setTrimeshType(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, type));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, type));
 
     return 0;
 }
@@ -850,9 +847,9 @@ vrpn_int32 vrpn_ForceDevice::decode_trimeshTransform(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, objNum));
     for (i = 0; i < 16; i++)
-        CHECK(vrpn_unbuffer(&mptr, &(homMatrix[i])));
+        (vrpn_unbuffer(&mptr, &(homMatrix[i])));
 
     return 0;
 }
@@ -892,8 +889,8 @@ vrpn_int32 vrpn_ForceDevice::decode_addObject(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, ParentNum));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, ParentNum));
 
     return 0;
 }
@@ -930,7 +927,7 @@ vrpn_int32 vrpn_ForceDevice::decode_addObjectExScene(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, objNum));
 
     return 0;
 }
@@ -973,10 +970,10 @@ vrpn_int32 vrpn_ForceDevice::decode_objectPosition(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, &Pos[0]));
-    CHECK(vrpn_unbuffer(&mptr, &Pos[1]));
-    CHECK(vrpn_unbuffer(&mptr, &Pos[2]));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, &Pos[0]));
+    (vrpn_unbuffer(&mptr, &Pos[1]));
+    (vrpn_unbuffer(&mptr, &Pos[2]));
 
     return 0;
 }
@@ -1023,11 +1020,11 @@ vrpn_int32 vrpn_ForceDevice::decode_objectOrientation(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, &axis[0]));
-    CHECK(vrpn_unbuffer(&mptr, &axis[1]));
-    CHECK(vrpn_unbuffer(&mptr, &axis[2]));
-    CHECK(vrpn_unbuffer(&mptr, angle));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, &axis[0]));
+    (vrpn_unbuffer(&mptr, &axis[1]));
+    (vrpn_unbuffer(&mptr, &axis[2]));
+    (vrpn_unbuffer(&mptr, angle));
 
     return 0;
 }
@@ -1070,10 +1067,10 @@ vrpn_int32 vrpn_ForceDevice::decode_objectScale(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, &Scale[0]));
-    CHECK(vrpn_unbuffer(&mptr, &Scale[1]));
-    CHECK(vrpn_unbuffer(&mptr, &Scale[2]));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, &Scale[0]));
+    (vrpn_unbuffer(&mptr, &Scale[1]));
+    (vrpn_unbuffer(&mptr, &Scale[2]));
 
     return 0;
 }
@@ -1110,7 +1107,7 @@ vrpn_int32 vrpn_ForceDevice::decode_removeObject(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, objNum));
 
     return 0;
 }
@@ -1147,7 +1144,7 @@ vrpn_int32 vrpn_ForceDevice::decode_clearTrimesh(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, objNum));
 
     return 0;
 }
@@ -1189,8 +1186,8 @@ vrpn_int32 vrpn_ForceDevice::decode_moveToParent(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, parentNum));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, parentNum));
 
     return 0;
 }
@@ -1241,12 +1238,12 @@ vrpn_int32 vrpn_ForceDevice::decode_setHapticOrigin(const char *buffer,
     }
 
     for (i = 0; i < 3; i++)
-        CHECK(vrpn_unbuffer(&mptr, &Pos[i]));
+        (vrpn_unbuffer(&mptr, &Pos[i]));
 
     for (i = 0; i < 3; i++)
-        CHECK(vrpn_unbuffer(&mptr, &axis[i]));
+        (vrpn_unbuffer(&mptr, &axis[i]));
 
-    CHECK(vrpn_unbuffer(&mptr, angle));
+    (vrpn_unbuffer(&mptr, angle));
     return 0;
 }
 
@@ -1283,7 +1280,7 @@ vrpn_int32 vrpn_ForceDevice::decode_setHapticScale(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, scale));
+    (vrpn_unbuffer(&mptr, scale));
 
     return 0;
 }
@@ -1334,12 +1331,12 @@ vrpn_int32 vrpn_ForceDevice::decode_setSceneOrigin(const char *buffer,
     }
 
     for (i = 0; i < 3; i++)
-        CHECK(vrpn_unbuffer(&mptr, &Pos[i]));
+        (vrpn_unbuffer(&mptr, &Pos[i]));
 
     for (i = 0; i < 3; i++)
-        CHECK(vrpn_unbuffer(&mptr, &axis[i]));
+        (vrpn_unbuffer(&mptr, &axis[i]));
 
-    CHECK(vrpn_unbuffer(&mptr, angle));
+    (vrpn_unbuffer(&mptr, angle));
 
     return 0;
 }
@@ -1381,8 +1378,8 @@ vrpn_int32 vrpn_ForceDevice::decode_setObjectIsTouchable(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, objNum));
-    CHECK(vrpn_unbuffer(&mptr, IsTouchable));
+    (vrpn_unbuffer(&mptr, objNum));
+    (vrpn_unbuffer(&mptr, IsTouchable));
 
     return 0;
 }
@@ -1438,16 +1435,16 @@ vrpn_int32 vrpn_ForceDevice::decode_forcefield(
     }
 
     for (i = 0; i < 3; i++)
-        CHECK(vrpn_unbuffer(&mptr, &(origin[i])));
+        (vrpn_unbuffer(&mptr, &(origin[i])));
 
     for (i = 0; i < 3; i++)
-        CHECK(vrpn_unbuffer(&mptr, &(force[i])));
+        (vrpn_unbuffer(&mptr, &(force[i])));
 
     for (i = 0; i < 3; i++)
         for (j = 0; j < 3; j++)
-            CHECK(vrpn_unbuffer(&mptr, &(jacobian[i][j])));
+            (vrpn_unbuffer(&mptr, &(jacobian[i][j])));
 
-    CHECK(vrpn_unbuffer(&mptr, radius));
+    (vrpn_unbuffer(&mptr, radius));
 
     return 0;
 }
@@ -1486,7 +1483,7 @@ vrpn_int32 vrpn_ForceDevice::decode_error(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, error_code));
+    (vrpn_unbuffer(&mptr, error_code));
 
     return 0;
 }
@@ -1574,7 +1571,7 @@ vrpn_int32 vrpn_ForceDevice::decode_enableConstraint(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, enable));
+    (vrpn_unbuffer(&mptr, enable));
 
     return 0;
 }
@@ -1636,7 +1633,7 @@ vrpn_int32 vrpn_ForceDevice::decode_setConstraintMode(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, &modeint));
+    (vrpn_unbuffer(&mptr, &modeint));
 
     switch (modeint) {
     case 0:
@@ -1785,7 +1782,7 @@ vrpn_int32 vrpn_ForceDevice::decode_setConstraintKSpring(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, k));
+    (vrpn_unbuffer(&mptr, k));
 
     return 0;
 }
@@ -1831,9 +1828,9 @@ vrpn_int32 vrpn_ForceDevice::decodePoint(const char *buffer,
         return -1;
     }
 
-    CHECK(vrpn_unbuffer(&mptr, x));
-    CHECK(vrpn_unbuffer(&mptr, y));
-    CHECK(vrpn_unbuffer(&mptr, z));
+    (vrpn_unbuffer(&mptr, x));
+    (vrpn_unbuffer(&mptr, y));
+    (vrpn_unbuffer(&mptr, z));
 
     return 0;
 }

--- a/vrpn_FunctionGenerator.C
+++ b/vrpn_FunctionGenerator.C
@@ -162,13 +162,7 @@ vrpn_int32 vrpn_FunctionGenerator_function_script::
 decode_from( const char** buf, vrpn_int32& len )
 {
 	vrpn_int32 newlen;
-	if( 0 > vrpn_unbuffer( buf, &newlen ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_function_script::decode_from:  "
-				"payload error (couldn't unbuffer length).\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(buf, &newlen);
 	len -= sizeof( vrpn_uint32);
 
 	if( len < newlen )
@@ -313,13 +307,7 @@ decode_from( const char** buf, vrpn_int32& len )
 		return -1;
 	}
 	int myCode;
-	if( 0 > vrpn_unbuffer( buf, &myCode ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_channel::decode_from:  "
-				"unable to unbuffer function type.\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(buf, &myCode);
 	// if we don't have the right function type, create a new
 	// one of the appropriate type and delete the old one
 	if( myCode != function->getFunctionCode() )
@@ -1576,13 +1564,7 @@ decode_channel( const char* buf, const vrpn_int32 len, vrpn_uint32& channelNum,
 	const char* mybuf = buf;
 	vrpn_int32 mylen = len;
 	vrpn_uint32 myNum = 0;
-	if( 0 > vrpn_unbuffer( &mybuf, &myNum ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Server::decode_channel:  "
-				"message payload error (couldn't unbuffer)\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&mybuf, &myNum);
 	mylen -= sizeof( myNum );
 	channelNum = myNum;
 	if( 0 > channel.decode_from( &mybuf, mylen ) )
@@ -1661,13 +1643,7 @@ decode_channel_reply( const char* buf, const vrpn_int32 len, vrpn_uint32& channe
 	const char* mybuf = buf;
 	vrpn_int32 mylen = len;
 	vrpn_uint32 myNum = 0;
-	if( 0 > vrpn_unbuffer( &mybuf, &myNum ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Remote::decode_channel_reply:  "
-				"unable to unbuffer channel number.\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&mybuf, &myNum);
 	if( myNum >= vrpn_FUNCTION_CHANNELS_MAX )
 	{
 		fprintf( stderr, "vrpn_FunctionGenerator_Remote::decode_channel_reply:  "
@@ -1728,13 +1704,7 @@ decode_channel_request( const char* buf, const vrpn_int32 len, vrpn_uint32& chan
 		return -1;
 	}
 	const char* mybuf = buf;
-	if( 0 > vrpn_unbuffer( &mybuf, &channelNum ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Server::decode_channel_request:  "
-				"unable to unbuffer channel %d", channelNum );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&mybuf, &channelNum);
 	return 0;
 }
 
@@ -1783,13 +1753,7 @@ decode_sampleRate_request( const char* buf, const vrpn_int32 len, vrpn_float32& 
 		return -1;
 	}
 	const char* mybuf = buf;
-	if( 0 > vrpn_unbuffer( &mybuf, &sampleRate ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Server::decode_sampleRate_request:  "
-				"unable to unbuffer sample rate" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&mybuf, &sampleRate);
 	return 0;
 }
 
@@ -1829,13 +1793,7 @@ decode_start_reply( const char* buf, const vrpn_int32 len, vrpn_bool& isStarted 
 		return -1;
 	}
 	const char* mybuf = buf;
-	if( 0 > vrpn_unbuffer( &mybuf, &isStarted ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Remote::decode_start_reply:  "
-				"unable to unbuffer stop condition.\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&mybuf, &isStarted);
 	return 0;
 }
 
@@ -1874,13 +1832,7 @@ decode_stop_reply( const char* buf, const vrpn_int32 len, vrpn_bool& isStopped )
 		fflush( stderr );
 		return -1;
 	}
-	if( 0 > vrpn_unbuffer( &buf, &isStopped ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Remote::decode_stop_reply:  "
-				"unable to unbuffer stop condition.\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&buf, &isStopped);
 	return 0;
 }
 
@@ -1920,13 +1872,7 @@ decode_sampleRate_reply( const char* buf, const vrpn_int32 len )
 		return -1;
 	}
 	vrpn_float32 myRate = 0;
-	if( 0 > vrpn_unbuffer( &buf, &myRate ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Remote::decode_sampleRate_reply:  "
-				"unable to unbuffer sample rate.\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&buf, &myRate);
 	this->sampleRate = myRate;
 	return 0;
 }
@@ -1976,13 +1922,7 @@ decode_interpreterDescription_reply( const char* buf, const vrpn_int32 len, char
 		return -1;
 	}
 	vrpn_int32 dlength = 0;
-	if( 0 > vrpn_unbuffer( &buf, &dlength ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Remote::decode_interpreterDescription_reply:  "
-				"unable to unbuffer description length.\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&buf, &dlength);
         try { *desc = new char[dlength + 1]; }
         catch (...) {
           fprintf(stderr, "vrpn_FunctionGenerator_Remote::decode_interpreterDescription_reply:  "
@@ -2041,14 +1981,8 @@ decode_error_reply( const char* buf, const vrpn_int32 len, FGError& error, vrpn_
 	}
 	int myError = NO_FG_ERROR;
 	vrpn_int32 myChannel = -1;
-	if( 0 > vrpn_unbuffer( &buf, &myError ) 
-		|| 0 > vrpn_unbuffer( &buf, &myChannel ) )
-	{
-		fprintf( stderr, "vrpn_FunctionGenerator_Remote::decode_error_reply:  "
-				"unable to unbuffer error & channel.\n" );
-		fflush( stderr );
-		return -1;
-	}
+        vrpn_unbuffer(&buf, &myError);
+        vrpn_unbuffer(&buf, &myChannel);
 	error = FGError( myError );
 	channel = myChannel;
 	return 0;

--- a/vrpn_Imager.C
+++ b/vrpn_Imager.C
@@ -1119,9 +1119,7 @@ int vrpn_Imager_Server::handle_throttle_message(void *userdata,
 
     // Get the requested number of frames from the buffer
     vrpn_int32 frames_to_send;
-    if (vrpn_unbuffer(&bufptr, &frames_to_send)) {
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, &frames_to_send);
 
     // If the requested number of frames is negative, then we set
     // for unbounded sending.  The next time a begin_frame message
@@ -1215,16 +1213,12 @@ int vrpn_Imager_Remote::handle_description_message(void *userdata,
     int i;
 
     // Get my new information from the buffer
-    if (vrpn_unbuffer(&bufptr, &me->d_nDepth) ||
-        vrpn_unbuffer(&bufptr, &me->d_nRows) ||
-        vrpn_unbuffer(&bufptr, &me->d_nCols) ||
-        vrpn_unbuffer(&bufptr, &me->d_nChannels)) {
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, &me->d_nDepth);
+    vrpn_unbuffer(&bufptr, &me->d_nRows);
+    vrpn_unbuffer(&bufptr, &me->d_nCols);
+    vrpn_unbuffer(&bufptr, &me->d_nChannels);
     for (i = 0; i < me->d_nChannels; i++) {
-        if (!me->d_channels[i].unbuffer(&bufptr)) {
-            return -1;
-        }
+      me->d_channels[i].unbuffer(&bufptr);
     }
 
     // Go down the list of callbacks that have been registered.
@@ -1248,18 +1242,14 @@ int vrpn_Imager_Remote::handle_region_message(void *userdata,
     // the start of the data in the buffer).  Set it to valid and then
     // call the user callback and then set it to invalid before
     // deleting it.
-    if (vrpn_unbuffer(&bufptr, &reg.d_chanIndex) ||
-        vrpn_unbuffer(&bufptr, &reg.d_dMin) ||
-        vrpn_unbuffer(&bufptr, &reg.d_dMax) ||
-        vrpn_unbuffer(&bufptr, &reg.d_rMin) ||
-        vrpn_unbuffer(&bufptr, &reg.d_rMax) ||
-        vrpn_unbuffer(&bufptr, &reg.d_cMin) ||
-        vrpn_unbuffer(&bufptr, &reg.d_cMax) ||
-        vrpn_unbuffer(&bufptr, &reg.d_valType)) {
-        fprintf(stderr, "vrpn_Imager_Remote::handle_region_message(): Can't "
-                        "unbuffer parameters!\n");
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, &reg.d_chanIndex);
+    vrpn_unbuffer(&bufptr, &reg.d_dMin);
+    vrpn_unbuffer(&bufptr, &reg.d_dMax);
+    vrpn_unbuffer(&bufptr, &reg.d_rMin);
+    vrpn_unbuffer(&bufptr, &reg.d_rMax);
+    vrpn_unbuffer(&bufptr, &reg.d_cMin);
+    vrpn_unbuffer(&bufptr, &reg.d_cMax);
+    vrpn_unbuffer(&bufptr, &reg.d_valType);
     reg.d_valBuf = bufptr;
     reg.d_valid = true;
 
@@ -1295,13 +1285,12 @@ int vrpn_Imager_Remote::handle_begin_frame_message(void *userdata,
     vrpn_IMAGERBEGINFRAMECB bf;
 
     bf.msg_time = p.msg_time;
-    if (vrpn_unbuffer(&bufptr, &bf.dMin) || vrpn_unbuffer(&bufptr, &bf.dMax) ||
-        vrpn_unbuffer(&bufptr, &bf.rMin) || vrpn_unbuffer(&bufptr, &bf.rMax) ||
-        vrpn_unbuffer(&bufptr, &bf.cMin) || vrpn_unbuffer(&bufptr, &bf.cMax)) {
-        fprintf(stderr, "vrpn_Imager_Remote::handle_begin_frame_message(): "
-                        "Can't unbuffer parameters!\n");
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, &bf.dMin);
+    vrpn_unbuffer(&bufptr, &bf.dMax);
+    vrpn_unbuffer(&bufptr, &bf.rMin);
+    vrpn_unbuffer(&bufptr, &bf.rMax);
+    vrpn_unbuffer(&bufptr, &bf.cMin);
+    vrpn_unbuffer(&bufptr, &bf.cMax);
 
     // ONLY if we have gotten a description message,
     // Go down the list of callbacks that have been registered.
@@ -1321,13 +1310,12 @@ int vrpn_Imager_Remote::handle_end_frame_message(void *userdata,
     vrpn_IMAGERENDFRAMECB ef;
 
     ef.msg_time = p.msg_time;
-    if (vrpn_unbuffer(&bufptr, &ef.dMin) || vrpn_unbuffer(&bufptr, &ef.dMax) ||
-        vrpn_unbuffer(&bufptr, &ef.rMin) || vrpn_unbuffer(&bufptr, &ef.rMax) ||
-        vrpn_unbuffer(&bufptr, &ef.cMin) || vrpn_unbuffer(&bufptr, &ef.cMax)) {
-        fprintf(stderr, "vrpn_Imager_Remote::handle_end_frame_message(): Can't "
-                        "unbuffer parameters!\n");
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, &ef.dMin);
+    vrpn_unbuffer(&bufptr, &ef.dMax);
+    vrpn_unbuffer(&bufptr, &ef.rMin);
+    vrpn_unbuffer(&bufptr, &ef.rMax);
+    vrpn_unbuffer(&bufptr, &ef.cMin);
+    vrpn_unbuffer(&bufptr, &ef.cMax);
 
     // ONLY if we have gotten a description message,
     // Go down the list of callbacks that have been registered.
@@ -1347,11 +1335,7 @@ int vrpn_Imager_Remote::handle_discarded_frames_message(void *userdata,
     vrpn_IMAGERDISCARDEDFRAMESCB df;
 
     df.msg_time = p.msg_time;
-    if (vrpn_unbuffer(&bufptr, &df.count)) {
-        fprintf(stderr, "vrpn_Imager_Remote::handle_discarded_frames_message():"
-                        " Can't unbuffer parameters!\n");
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, &df.count);
 
     // ONLY if we have gotten a description message,
     // Go down the list of callbacks that have been registered.
@@ -2013,20 +1997,18 @@ int vrpn_ImagerPose_Remote::handle_description_message(void *userdata,
     vrpn_ImagerPose_Remote *me = (vrpn_ImagerPose_Remote *)userdata;
 
     // Get my new information from the buffer
-    if (vrpn_unbuffer(&bufptr, &me->d_origin[0]) ||
-        vrpn_unbuffer(&bufptr, &me->d_origin[1]) ||
-        vrpn_unbuffer(&bufptr, &me->d_origin[2]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dDepth[0]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dDepth[1]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dDepth[2]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dRow[0]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dRow[1]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dRow[2]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dCol[0]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dCol[1]) ||
-        vrpn_unbuffer(&bufptr, &me->d_dCol[2])) {
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, &me->d_origin[0]);
+    vrpn_unbuffer(&bufptr, &me->d_origin[1]);
+    vrpn_unbuffer(&bufptr, &me->d_origin[2]);
+    vrpn_unbuffer(&bufptr, &me->d_dDepth[0]);
+    vrpn_unbuffer(&bufptr, &me->d_dDepth[1]);
+    vrpn_unbuffer(&bufptr, &me->d_dDepth[2]);
+    vrpn_unbuffer(&bufptr, &me->d_dRow[0]);
+    vrpn_unbuffer(&bufptr, &me->d_dRow[1]);
+    vrpn_unbuffer(&bufptr, &me->d_dRow[2]);
+    vrpn_unbuffer(&bufptr, &me->d_dCol[0]);
+    vrpn_unbuffer(&bufptr, &me->d_dCol[1]);
+    vrpn_unbuffer(&bufptr, &me->d_dCol[2]);
 
     // Go down the list of callbacks that have been registered.
     // Fill in the parameter and call each.

--- a/vrpn_Imager.h
+++ b/vrpn_Imager.h
@@ -96,20 +96,17 @@ protected:
         }
     }
 
-    inline bool unbuffer(const char **buffer)
+    inline void unbuffer(const char **buffer)
     {
         vrpn_uint32 compression;
-        if (vrpn_unbuffer(buffer, &minVal) || vrpn_unbuffer(buffer, &maxVal) ||
-            vrpn_unbuffer(buffer, &offset) || vrpn_unbuffer(buffer, &scale) ||
-            vrpn_unbuffer(buffer, &compression) ||
-            vrpn_unbuffer(buffer, name, sizeof(name)) ||
-            vrpn_unbuffer(buffer, units, sizeof(units))) {
-            return false;
-        }
-        else {
-            d_compression = (ChannelCompression)compression;
-            return true;
-        }
+        vrpn_unbuffer(buffer, &minVal);
+        vrpn_unbuffer(buffer, &maxVal);
+        vrpn_unbuffer(buffer, &offset);
+        vrpn_unbuffer(buffer, &scale);
+        vrpn_unbuffer(buffer, &compression);
+        vrpn_unbuffer(buffer, name, sizeof(name));
+        vrpn_unbuffer(buffer, units, sizeof(units));
+        d_compression = (ChannelCompression)compression;
     }
 
     typedef enum { NONE = 0 } ChannelCompression;

--- a/vrpn_Imager_Stream_Buffer.C
+++ b/vrpn_Imager_Stream_Buffer.C
@@ -249,9 +249,7 @@ int vrpn_Imager_Stream_Buffer::static_handle_throttle_message(
 
     // Get the requested number of frames from the buffer
     vrpn_int32 frames_to_send;
-    if (vrpn_unbuffer(&bufptr, &frames_to_send)) {
-        return -1;
-    }
+    vrpn_unbuffer(&bufptr, &frames_to_send);
 
     me->d_shared_state.set_throttle_request(frames_to_send);
     return 0;

--- a/vrpn_Shared.C
+++ b/vrpn_Shared.C
@@ -19,9 +19,6 @@
 #include <netinet/in.h> // for htonl, htons
 #endif
 
-#define CHECK(a) \
-    if (a == -1) return -1
-
 #if defined(VRPN_USE_WINSOCK_SOCKETS)
 /* from HP-UX */
 struct timezone {
@@ -317,17 +314,15 @@ VRPN_API int vrpn_buffer(char **insertPt, vrpn_int32 *buflen,
     the VRPN defined wire protocol.
 */
 
-VRPN_API int vrpn_unbuffer(const char **buffer, timeval *t)
+VRPN_API void vrpn_unbuffer(const char **buffer, timeval *t)
 {
     vrpn_int32 sec, usec;
 
-    CHECK(vrpn_unbuffer(buffer, &sec));
-    CHECK(vrpn_unbuffer(buffer, &usec));
+    vrpn_unbuffer(buffer, &sec);
+    vrpn_unbuffer(buffer, &usec);
 
     t->tv_sec = sec;
     t->tv_usec = usec;
-
-    return 0;
 }
 
 /** Utility routine for taking a string of specified length from a buffer that

--- a/vrpn_Shared.h
+++ b/vrpn_Shared.h
@@ -214,7 +214,7 @@ extern VRPN_API int vrpn_unbuffer(const char **buffer, char *string,
                                   vrpn_int32 length);
 
 // Read and write timeval.
-extern VRPN_API int vrpn_unbuffer(const char **buffer, timeval *t);
+extern VRPN_API void vrpn_unbuffer(const char **buffer, timeval *t);
 extern VRPN_API int vrpn_buffer(char **insertPt, vrpn_int32 *buflen,
                                 const timeval t);
 
@@ -492,10 +492,9 @@ inline int vrpn_buffer(ByteT **insertPt, vrpn_int32 *buflen, const T inVal)
 }
 
 template <typename T, typename ByteT>
-inline int vrpn_unbuffer(ByteT **input, T *lvalue)
+inline void vrpn_unbuffer(ByteT **input, T *lvalue)
 {
     *lvalue = ::vrpn_unbuffer<T, ByteT>(*input);
-    return 0;
 }
 
 // Returns true if tests work and false if they do not.


### PR DESCRIPTION
…ls.  They always returned okay in any case.

Removing tests for error return on vrpn_unbuffer in the rest of the code.

This runs a risk of screwing up code that uses vrpn_unbuffer in out-of-library client code, so we many want to leave it alone and not merge this.