### PR TITLE
Add Qt5 support for hid_gi

### DIFF
--- a/hid_gui/CMakeLists.txt
+++ b/hid_gui/CMakeLists.txt
@@ -29,12 +29,22 @@ set(UIS
 	mainwindow.ui
 	plot.ui)
 
-find_package(Qt4 4.7)
-if(QT_FOUND)
+find_package(Qt5 COMPONENTS Gui Widgets)
+if(NOT TARGET Qt5::Core)
+	message("No Qt5")
+	find_package(Qt4 4.7)
+endif()
+
+if(TARGET Qt5::Core)
+	qt5_wrap_ui(GENERATED_SOURCES ${UIS})
+	qt5_wrap_cpp(GENERATED_SOURCES ${MOCS})
+elseif(QT_FOUND)
 	include(${QT_USE_FILE})
 	qt4_wrap_ui(GENERATED_SOURCES ${UIS})
 	qt4_wrap_cpp(GENERATED_SOURCES ${MOCS})
+endif()
 
+if(TARGET Qt5::Core OR QT_FOUND)
 	source_group("Generated Sources - Do Not Edit"
 		FILES
 		${GENERATED_SOURCES})
@@ -51,4 +61,10 @@ if(QT_FOUND)
 		${RESOURCES})
 	target_link_libraries(vrpn_hid_gui ${QT_LIBRARIES} vrpnserver)
 endif()
-
+if(TARGET Qt5::Core)
+	qt5_wrap_ui(GENERATED_SOURCES ${UIS})
+	qt5_wrap_cpp(GENERATED_SOURCES ${MOCS})
+	qt5_use_modules(vrpn_hid_gui Widgets)
+elseif(QT_FOUND)
+	target_link_libraries(vrpn_hid_gui ${QT_LIBRARIES})
+endif()

--- a/hid_gui/main.cpp
+++ b/hid_gui/main.cpp
@@ -22,7 +22,12 @@
 #include "vrpn_HumanInterface.h"
 
 // Library/third-party includes
-#include <QtGui/QApplication>
+#include <QtGlobal>
+#if QT_VERSION >= 0x050000
+    #include <QApplication>
+#else
+    #include <QtGui/QApplication>
+#endif
 
 // Standard includes
 #include <sstream>
@@ -38,7 +43,7 @@ int usage(char * argv0) {
 
 	       "%s VEND PROD [N]\n"
 	       "	Open HID device number N (default to 0) that matches\n"
-	       "	vendor VEND and product PROD, in _decimal_\n\n"
+	       "	vendor VEND and product PROD, in hex\n\n"
 
 	       ,
 	       argv0, argv0, argv0);
@@ -60,15 +65,17 @@ int main(int argc, char *argv[]) {
 	unsigned N = 0; // Which device to open?
 	if (argc >= 3) {
 		vrpn_uint16 vend;
-		std::istringstream vendS(argv[1]);
+		std::stringstream vendS(argv[1]);
+		vendS << std::hex << argv[1];
 		if (!(vendS >> vend)) {
-			return failedOnArgument(1, "a decimal vendor ID", argv);
+			return failedOnArgument(1, "a hex vendor ID (four characters)", argv);
 		}
 
 		vrpn_uint16 prod;
-		std::istringstream prodS(argv[2]);
+		std::stringstream prodS;
+		prodS << std::hex << argv[2];
 		if (!(prodS >> prod)) {
-			return failedOnArgument(2, "a decimal product ID", argv);
+			return failedOnArgument(2, "a hex product ID (four characters)", argv);
 		}
 
 		if (argc >= 4) {


### PR DESCRIPTION
The VRPN hid_gui tool has been modified: it now accepts hex instead of decimal for the vendor/product. It also now builds with Qt5 if you have it (still builds with 4 as well), since for some reason I couldn't get it to run correctly on Debian Buster with 4.