### PR TITLE
vrpn_3DConnexion: add support for SpaceMouse Compact device

### DIFF
--- a/server_src/vrpn.cfg
+++ b/server_src/vrpn.cfg
@@ -2101,6 +2101,7 @@
 #vrpn_3DConnexion_Traveler device0
 #vrpn_3DConnexion_SpaceMouse device0
 #vrpn_3DConnexion_SpaceMousePro device0
+#vrpn_3DConnexion_SpaceMouseCompact device0
 #vrpn_3DConnexion_SpaceMouseWireless device0
 #vrpn_3DConnexion_SpaceExplorer device0
 #vrpn_3DConnexion_SpaceBall5000 device0
@@ -3466,4 +3467,3 @@
 #  analog[8] is the Z axis for the magnetometer, in microTesla
 
 #vrpn_Vality_vGlass Vality0
-

--- a/server_src/vrpn_Generic_server_object.C
+++ b/server_src/vrpn_Generic_server_object.C
@@ -5594,6 +5594,10 @@ vrpn_Generic_Server_Object::vrpn_Generic_Server_Object(
                     VRPN_CHECK(templated_setup_device_name_only<
                         vrpn_3DConnexion_SpaceMousePro>);
                 }
+                else if (VRPN_ISIT("vrpn_3DConnexion_SpaceMouseCompact")) {
+                    VRPN_CHECK(templated_setup_device_name_only<
+                        vrpn_3DConnexion_SpaceMouseCompact>);
+                }
                 else if (VRPN_ISIT("vrpn_3DConnexion_SpaceMouseWireless")) {
                     VRPN_CHECK(templated_setup_device_name_only<
                         vrpn_3DConnexion_SpaceMouseWireless>);

--- a/vrpn_3DConnexion.C
+++ b/vrpn_3DConnexion.C
@@ -24,12 +24,14 @@ typedef struct input_devinfo {
 // USB vendor and product IDs for the models we support
 static const vrpn_uint16 vrpn_3DCONNEXION_VENDOR = 0x046d; //1133;	// 3Dconnexion is made by Logitech
 static const vrpn_uint16 vrpn_SPACEMOUSEWIRELESS_VENDOR = 9583; 	// Made by a different vendor...
+static const vrpn_uint16 vrpn_SPACEMOUSECOMPACT_VENDOR = vrpn_SPACEMOUSEWIRELESS_VENDOR;
 static const vrpn_uint16 vrpn_3DCONNEXION_TRAVELER = 50723;
 static const vrpn_uint16 vrpn_3DCONNEXION_NAVIGATOR = 50726;
 static const vrpn_uint16 vrpn_3DCONNEXION_NAVIGATOR_FOR_NOTEBOOKS = 0xc628;	// 50728;
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEEXPLORER = 0xc627;   // 50727
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEMOUSE = 50691;
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEMOUSEPRO = 50731;
+static const vrpn_uint16 vrpn_3DCONNEXION_SPACEMOUSECOMPACT = 50741;
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEMOUSEWIRELESS = 50735;
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEBALL5000 = 0xc621;   // 50721;
 static const vrpn_uint16 vrpn_3DCONNEXION_SPACEPILOT =  0xc625;
@@ -347,6 +349,11 @@ vrpn_3DConnexion_SpaceMouse::vrpn_3DConnexion_SpaceMouse(const char *name, vrpn_
 vrpn_3DConnexion_SpaceMousePro::vrpn_3DConnexion_SpaceMousePro(const char *name, vrpn_Connection *c)
     : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEPRO), 27, name, c, vrpn_3DCONNEXION_VENDOR, vrpn_3DCONNEXION_SPACEMOUSEPRO)
 {	// 15 physical buttons are numbered: 0-2, 4-5, 8, 12-15, 22-26
+}
+
+vrpn_3DConnexion_SpaceMouseCompact::vrpn_3DConnexion_SpaceMouseCompact(const char *name, vrpn_Connection *c)
+    : vrpn_3DConnexion(new vrpn_HidProductAcceptor(vrpn_SPACEMOUSECOMPACT_VENDOR, vrpn_3DCONNEXION_SPACEMOUSECOMPACT), 2, name, c, vrpn_SPACEMOUSECOMPACT_VENDOR, vrpn_3DCONNEXION_SPACEMOUSECOMPACT)
+{
 }
 
 vrpn_3DConnexion_SpaceMouseWireless::vrpn_3DConnexion_SpaceMouseWireless(const char *name, vrpn_Connection *c)

--- a/vrpn_3DConnexion.h
+++ b/vrpn_3DConnexion.h
@@ -12,8 +12,8 @@
 #include "vrpn_Types.h"                 // for vrpn_uint32, vrpn_uint8
 
 // Device drivers for the 3DConnexion SpaceNavigator and SpaceTraveler
-// SpaceExplorer, SpaceMouse, SpaceMousePro, Spaceball5000, SpacePilot
-// devices, connecting to them as HID devices (USB).
+// SpaceExplorer, SpaceMouse, SpaceMousePro, SpaceMouseCompact, Spaceball5000,
+// SpacePilot devices, connecting to them as HID devices (USB).
 
 // Exposes two VRPN device classes: Button and Analog.
 // Analogs are mapped to the six channels, each in the range (-1..1).
@@ -138,6 +138,14 @@ public:
 protected:
 };
 
+class VRPN_API vrpn_3DConnexion_SpaceMouseCompact : public vrpn_3DConnexion {
+public:
+	vrpn_3DConnexion_SpaceMouseCompact(const char *name, vrpn_Connection *c = 0);
+	virtual ~vrpn_3DConnexion_SpaceMouseCompact() {};
+
+protected:
+};
+
 class VRPN_API vrpn_3DConnexion_SpaceMouseWireless : public vrpn_3DConnexion {
 public:
 	vrpn_3DConnexion_SpaceMouseWireless(const char *name, vrpn_Connection *c = 0);
@@ -172,4 +180,3 @@ protected:
 
 // end of VRPN_3DCONNEXION_H
 #endif
-


### PR DESCRIPTION
Adds support for one more member of the 3DConnexion SpaceMouse family.