### PR TITLE
Fix proper deletion

### DIFF
--- a/client_src/test_imager.C
+++ b/client_src/test_imager.C
@@ -3,7 +3,7 @@
 #include <stdlib.h>                     // for rand
 
 #include "vrpn_Configure.h"             // for VRPN_CALLBACK
-#include  "vrpn_Connection.h"
+#include "vrpn_Connection.h"
 #include "vrpn_Imager.h"                // for vrpn_IMAGERREGIONCB, etc
 #include "vrpn_Types.h"                 // for vrpn_uint16
 
@@ -172,6 +172,8 @@ int main(int, char *[])
 
   if (clt) { delete clt; }
   if (svr) { delete svr; }
+
+  svrcon->removeReference();
 
   return 0;
 }

--- a/vrpn_Imager_Stream_Buffer.C
+++ b/vrpn_Imager_Stream_Buffer.C
@@ -88,7 +88,11 @@ vrpn_Imager_Stream_Buffer::vrpn_Imager_Stream_Buffer(
 
 vrpn_Imager_Stream_Buffer::~vrpn_Imager_Stream_Buffer()
 {
-  if (d_logging_thread) { stop_logging_thread(); }
+    if (d_logging_thread) {
+      stop_logging_thread();
+      delete d_logging_thread;
+      d_logging_thread = NULL;
+    }
     if (d_imager_server_name) {
         try {
           delete[] d_imager_server_name;
@@ -218,6 +222,7 @@ void vrpn_Imager_Stream_Buffer::handle_got_first_connection(void)
           delete d_logging_thread;
         } catch (...) {
           fprintf(stderr, "vrpn_Imager_Stream_Buffer::handle_got_first_connection(): delete failed\n");
+          d_logging_thread = NULL;
           return;
         }
         d_logging_thread = NULL;


### PR DESCRIPTION
Properly deletes thread object and connection object.
This addresses warnings pointed out by auto code checker LGTM.