### PR TITLE
Fix for issue 263

### DIFF
--- a/vrpn_5DT16.C
+++ b/vrpn_5DT16.C
@@ -105,13 +105,13 @@ int vrpn_5dt16::reset (void)
   char text[50];
   sprintf(text,"Hardware Version %i.0%i",l_inbuf[0],l_inbuf[1]); // hardware version
   VRPN_MSG_WARNING(text);
-  if (l_inbuf[2] | 1) //right or left glove
+  if (l_inbuf[2] & 1) //right or left glove
   {
   	  VRPN_MSG_WARNING ("A right glove is ready");
   } else {
 	  VRPN_MSG_WARNING ("A left glove is ready");
   }
-  if (l_inbuf[3] | 1) //wireless glove or wired
+  if (l_inbuf[3] & 1) //wireless glove or wired
   {
 	  VRPN_MSG_WARNING ("no wireless glove");
   } else {

--- a/vrpn_Analog_5dt.C
+++ b/vrpn_Analog_5dt.C
@@ -191,12 +191,12 @@ vrpn_5dt::reset (void)
     sprintf (l_errmsg, "vrpn_5dt: glove \"%s\"version %d.%d\n", &l_inbuf [16], l_inbuf [2], l_inbuf [3]);
     VRPN_MSG_INFO (l_errmsg);
 
-    if (l_inbuf[4] | 1) {
+    if (l_inbuf[4] & 1) {
       VRPN_MSG_INFO ("A right glove is ready");
     } else {
       VRPN_MSG_INFO ("A left glove is ready");
     }
-    if (l_inbuf[5] | 16) {
+    if (l_inbuf[5] & 16) {
       VRPN_MSG_INFO ("Pitch and Roll are available");
     } else {
       VRPN_MSG_INFO ("Pitch and Roll are not available");


### PR DESCRIPTION
(issue #263) Fixes incorrectly inserted "| 1" expression into "& 1". (if that is what the original intention was).

Test results:

```
$ make test
Running tests...
Test project /nfs_home/nhasabni/tmp/vrpn/build
    Start 1: test_imager
1/5 Test #1: test_imager ......................   Passed    1.07 sec
    Start 2: test_vrpn
2/5 Test #2: test_vrpn ........................   Passed   11.18 sec
    Start 3: test_loopback
3/5 Test #3: test_loopback ....................   Passed   10.97 sec
    Start 4: test_analogfly
4/5 Test #4: test_analogfly ...................   Passed   11.01 sec
    Start 5: test_logging
5/5 Test #5: test_logging .....................   Passed   51.88 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =  86.38 sec
```