### PR TITLE
deprecate CMAKE_HAVE_THREADS_LIBRARY

### DIFF
--- a/cmake/FindVRPN.cmake
+++ b/cmake/FindVRPN.cmake
@@ -112,7 +112,7 @@ list(APPEND _deps_check QUATLIB_FOUND)
 if(NOT WIN32)
 	find_package(Threads ${_vrpn_quiet})
 	list(APPEND _deps_libs ${CMAKE_THREAD_LIBS_INIT})
-	list(APPEND _deps_check CMAKE_HAVE_THREADS_LIBRARY)
+    list(APPEND _deps_check Threads_FOUND)
 endif()
 
 if(WIN32)

--- a/cmake/FindVRPN.cmake
+++ b/cmake/FindVRPN.cmake
@@ -112,7 +112,7 @@ list(APPEND _deps_check QUATLIB_FOUND)
 if(NOT WIN32)
 	find_package(Threads ${_vrpn_quiet})
 	list(APPEND _deps_libs ${CMAKE_THREAD_LIBS_INIT})
-    list(APPEND _deps_check Threads_FOUND)
+	list(APPEND _deps_check Threads_FOUND)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
`CMAKE_HAVE_THREADS_LIBRARY` is deprecated by modern CMake versions