### PR TITLE
Handle BUILD_SHARED_LIBS=TRUE in Findquatlib.cmake

### DIFF
--- a/cmake/Findquatlib.cmake
+++ b/cmake/Findquatlib.cmake
@@ -69,6 +69,7 @@ else()
 		NAMES
 		quat.lib
 		libquat.a
+		libquat.so
 		HINTS
 		"${QUATLIB_ROOT_DIR}"
 		PATH_SUFFIXES


### PR DESCRIPTION
If building vrpn with BUILD_SHARED_LIBS=ON, the quatlib library name will be `libquat.so` not `libquat.a`. This appears to be the only change necessary to support that build scenario.