### PR TITLE
Updated python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.12.1)
 project(VRPN)
 
 #-----------------------------------------------------------------------------
@@ -302,19 +302,15 @@ endif()
 
 # Passing just the major version works with as desired multi-python-capable find module such
 # as in latest CMake (2.8.9)
-find_package(PythonLibs ${_VRPN_PYTHON_VERSIONSEARCH} ${QUIET_IF_SUBPROJECT})
-if(PYTHONLIBS_FOUND)
-	if(PYTHONLIBS_VERSION_STRING)
+find_package(Python ${_VRPN_PYTHON_VERSIONSEARCH} COMPONENTS Development ${QUIET_IF_SUBPROJECT})
+if(Python_Development_FOUND)
+	if(Python_VERSION)
 		string(SUBSTRING
-			${PYTHONLIBS_VERSION_STRING}
+			${Python_VERSION}
 			0
 			1
 			vrpn_python_majorver)
 		set(PYTHON${vrpn_python_majorver}_FOUND ON)
-	elseif(PYTHON_LIBRARY MATCHES "python([23])")
-		set(PYTHON${CMAKE_MATCH_1}_FOUND ON)
-	elseif(_VRPN_PYTHON_VERSIONSEARCH)
-		set(PYTHON${_VRPN_PYTHON_VERSIONSEARCH}_FOUND ON)
 	else()
 		message(STATUS
 			"Warning: found python but couldn't determine which version. Please set either VRPN_PYTHON_IS_3 or VRPN_PYTHON_IS_2")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,9 +1,9 @@
 
-if(PYTHONLIBS_FOUND AND (VRPN_BUILD_PYTHON_HANDCODED_2X OR VRPN_BUILD_PYTHON_HANDCODED_3X))
+if(Python_Development_FOUND AND (VRPN_BUILD_PYTHON_HANDCODED_2X OR VRPN_BUILD_PYTHON_HANDCODED_3X))
 	include_directories(${PYTHON_INCLUDE_DIRS} "${CMAKE_CURRENT_SOURCE_DIR}")
 
 	set(PYTHONVERSIONDIR python)
-	if(PYTHON_LIBRARY MATCHES "python([23].[0-9]+)")
+	if(Python_VERSION MATCHES "python([23].[0-9]+)")
 		set(PYTHONVERSIONDIR "python${CMAKE_MATCH_1}/")
 	endif()
 
@@ -12,7 +12,7 @@ if(PYTHONLIBS_FOUND AND (VRPN_BUILD_PYTHON_HANDCODED_2X OR VRPN_BUILD_PYTHON_HAN
 	else()
 		add_definitions(-DCALLBACK_CALL=)
 	endif()
-	python_add_module(vrpn-python
+	python_add_library(vrpn-python MODULE
 		Base.cpp
 		Connection.cpp
 		Device.cpp
@@ -45,7 +45,7 @@ if(PYTHONLIBS_FOUND AND (VRPN_BUILD_PYTHON_HANDCODED_2X OR VRPN_BUILD_PYTHON_HAN
 		sender/include/Text_Sender.hpp
 		sender/sender.cpp
 		tools.cpp)
-	target_link_libraries(vrpn-python ${PYTHON_LIBRARIES} vrpnserver)
+	target_link_libraries(vrpn-python PRIVATE ${PYTHON_LIBRARIES} vrpnserver)
 	set_target_properties(vrpn-python
 		PROPERTIES
 		FOLDER "Python Bindings"

--- a/python/Device.cpp
+++ b/python/Device.cpp
@@ -88,7 +88,11 @@ namespace vrpn_python {
   PyObject *Device::getDateTimeFromTimeval(const struct timeval &time) {
     const time_t seconds = time.tv_sec;
     struct tm t;
+#ifdef	_WIN32
+    t = *gmtime(&seconds); {
+#else
     if (gmtime_r(&seconds, &t)) {
+#endif
       return PyDateTime_FromDateAndTime(t.tm_year+1900, t.tm_mon+1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, time.tv_usec);
     }
     return NULL;

--- a/python/README.txt
+++ b/python/README.txt
@@ -1,2 +1,4 @@
 This directory contains submissions from Damien Touraine that implements a Python interface to VRPN.  There is a SWIG-produced interface in ../vrpn_python that works with Python 2.7.  The version in this directory is hand-coded and works with both Python 2.7 and Python 3.
 
+See the examples directory for how to use this library.
+


### PR DESCRIPTION
This uses the more modern approach to finding and building Python libraries. It was added to get manually-wrapped Python3 code working on M1 macs.

This required changing the minimum CMake to 3.12.1.

It has been tested on M1 MacOS, Ubuntu 22.04, Windows 11, Raspberry Pi.