### PR TITLE
Added ability to see if a tracker is being accessed / is connected

### DIFF
--- a/vrpn_BaseClass.h
+++ b/vrpn_BaseClass.h
@@ -195,6 +195,8 @@ public:
 
     bool shutup; // if True, don't print the "No response from server" messages.
 
+    struct timeval time_last_ping_response;
+
     friend class SendTextMessageBoundCall;
     class SendTextMessageBoundCall {
     private:

--- a/vrpn_Connection.C
+++ b/vrpn_Connection.C
@@ -4354,9 +4354,18 @@ int vrpn_Endpoint::tryToMarshall(char *outbuf, vrpn_int32 &buflen,
     // by sending the stuff in them to see if this makes enough
     // room.  If not, we'll have to give up.
     if (!retval) {
+        
+#ifdef VERBOSE
+        fprintf(stderr, "Failed to marshall message of size %d, out buffer filled with %d bytes!\n",
+                len, numOut);
+#endif
         if (send_pending_reports() != 0) {
             return 0;
         }
+#ifdef VERBOSE
+        fprintf(stderr, "After sending, got %d bytes remaining in out buffer!\n",
+                numOut);
+#endif
         retval = marshall_message(outbuf, buflen, numOut, len, time, type,
                                   sender, buffer, sequenceNumber);
     }

--- a/vrpn_FileConnection.C
+++ b/vrpn_FileConnection.C
@@ -670,6 +670,7 @@ int vrpn_File_Connection::playone_to_filetime(timeval end_filetime)
     vrpn_Endpoint *endpoint = d_endpoints.front();
     timeval now;
     int retval;
+    int type, sender;
 
     // If we don't have a currentLogEntry, then we've gone past the end of the
     // file.
@@ -703,15 +704,15 @@ int vrpn_File_Connection::playone_to_filetime(timeval end_filetime)
 
     // Handle this log entry
     if (header.type >= 0) {
+        type = endpoint->local_type_id(header.type);
+        sender = endpoint->local_type_id(header.sender);
 #ifdef VERBOSE
         printf("vrpn_FC: Msg Sender (%s), Type (%s), at (%ld:%ld)\n",
-               endpoint->other_senders[header.sender].name,
-               endpoint->other_types[header.type].name, header.msg_time.tv_sec,
-               header.msg_time.tv_usec);
+               sender_name(sender), message_type_name(header.type),
+               header.msg_time.tv_sec, header.msg_time.tv_usec);
 #endif
         if (endpoint->local_type_id(header.type) >= 0) {
-            if (do_callbacks_for(endpoint->local_type_id(header.type),
-                                 endpoint->local_sender_id(header.sender),
+            if (do_callbacks_for(type, sender,
                                  header.msg_time, header.payload_len,
                                  header.buffer)) {
                 return -1;
@@ -834,7 +835,7 @@ void vrpn_File_Connection::find_superlative_user_times()
     }
 #ifdef VERBOSE
     else {
-        fprintf( stderr, "vrpn_File_Connection::find_superlative_user_times:  did not find a highest-time user message\n"
+        fprintf( stderr, "vrpn_File_Connection::find_superlative_user_times:  did not find a highest-time user message\n");
     }
 #endif
 
@@ -845,7 +846,7 @@ void vrpn_File_Connection::find_superlative_user_times()
     }
 #ifdef VERBOSE
     else {
-        fprintf( stderr, "vrpn_File_Connection::find_superlative_user_times:  did not find an earliest user message\n"
+        fprintf( stderr, "vrpn_File_Connection::find_superlative_user_times:  did not find an earliest user message\n");
     }
 #endif
 


### PR DESCRIPTION
Commit 1:
I fixed verbose logging compilation errors and also adding one that helped me fix a bug of mine.
Notably, VRPN crashed for me when I accidentally did not call mainloop on the trackers, only on the server-side connection itself. Maybe something that could be improved, though i have not found the root cause yet so no proposal there.

Commit 2:
For my project, I'd like to detect when a remote client is actively connected to a tracker exposed on the server.
Not just connected through vrpn_connection, but specifically connected to an individual tracker.
The easiest method I found is checking if the ping-pong-cycle of that tracker is active - however, I found, despite it's name, it is only active once until it connects initially. The design seemed to indicate it was once active forever, and this would be necessary for the server to determine if the tracker is still being accessed, so I made it continue indefinitely (once per second) and exposed the last ping response as a timestamp for both client and server to use.
This might be useful to other users, and is flexible enough for various variations of requirements.

Finally, something I wanted to implement but could not find a way to:
To improve UX in clients with graphical user interfaces, I would like to display trackers available on a remote server.
We can already iterate over all known trackers with `vrpn_Connection::sender_name(int sender)` until it returns NULL, but these do include trackers already created locally, and since servers to repeat trackers requested by clients back to the client, to add a remote id, using the same mechanism it reports REAL trackers it exposes, there is currently no way I found to tell if a tracker is available on a remote, or just requested by the client. If anybody got input on that, I'd be happy to work on that, too.

Thanks for reviewing!