### PR TITLE
Fix RequireOutOfSource build to work with FetchContent.

### DIFF
--- a/cmake/cmake-4.0.0-modules/RequireOutOfSourceBuild.cmake
+++ b/cmake/cmake-4.0.0-modules/RequireOutOfSourceBuild.cmake
@@ -15,7 +15,7 @@
 
 get_filename_component(_src "${CMAKE_SOURCE_DIR}" ABSOLUTE)
 get_filename_component(_cur_src "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
-get_filename_component(_bin "${CMAKE_BINARY_DIR}" ABSOLUTE)
+get_filename_component(_bin "${CMAKE_CURRENT_BINARY_DIR}" ABSOLUTE)
 
 string(LENGTH "${_src}" _src_len)
 string(LENGTH "${_cur_src}" _cur_src_len)


### PR DESCRIPTION
If VRPN is included in CMake via FetchContent, CMake will create an out-of-source build in ${CMAKE_BINARY_DIR}/_deps by default, in which case RequireOutOfSourceBuild.cmake fails as it checks against the global ${CMAKE_BINARY_DIR} instead of ${CMAKE_CURRENT_BINARY_DIR} used in the subbuild.